### PR TITLE
docs: post-v1.0.0 documentation pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 # Working on netbox-super-cli (for AI agents)
 
-This is the contributor guide for AI agents (and humans!) modifying this repo. The end-user-facing AI guide is the bundled Skill at `skills/netbox-super-cli/SKILL.md` (added in Phase 5).
+This is the contributor guide for AI agents (and humans!) modifying this repo. The end-user-facing AI guide is the bundled Skill at `skills/netbox-super-cli/SKILL.md`.
 
 ## Architecture cheat sheet
 
@@ -15,10 +15,13 @@ This is the contributor guide for AI agents (and humans!) modifying this repo. T
 - `nsc/model/` — the normalized command tree (data only, framework-free). The "brain".
 - `nsc/builder/` — converts a parsed schema into a `CommandModel`.
 - `nsc/cli/` — the Typer app; consumes a `CommandModel`.
-- `nsc/http/` — thin httpx wrapper (Phase 2+).
-- `nsc/output/` — formatters (Phase 2+).
-- `nsc/config/` — config loader + Pydantic models (Phase 1 has a minimal version).
+- `nsc/http/` — thin httpx wrapper: auth, retries, audit log.
+- `nsc/output/` — formatters (table/json/jsonl/yaml/csv) + error envelope.
+- `nsc/config/` — config loader + Pydantic models + ruamel.yaml round-trip writer.
 - `nsc/cache/` — disk cache for generated command-models.
+- `nsc/auth/` — login verification helpers (pre-flight probes, token rotate).
+- `nsc/aliases/` — curated alias resolver (`ls`, `get`, `rm`, `search`). Framework-free.
+- `nsc/skill/` — bundle-path helper for the portable `SKILL.md` shipped in the wheel.
 - `nsc/schemas/bundled/` — versioned NetBox OpenAPI snapshots, fallback when offline.
 
 The hard rule: **`nsc/model/` imports nothing from `nsc/cli/`, `nsc/http/`, or any framework.** If you need to add a dependency to `model/`, you're probably solving the wrong problem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Working on netbox-super-cli (for AI agents)
 
-This is the contributor guide for AI agents (and humans!) modifying this repo. The end-user-facing AI guide is the bundled Skill at `skills/netbox-super-cli/SKILL.md` (added in Phase 5).
+This is the contributor guide for AI agents (and humans!) modifying this repo. The end-user-facing AI guide is the bundled Skill at `skills/netbox-super-cli/SKILL.md`.
 
 ## Architecture cheat sheet
 
@@ -8,10 +8,13 @@ This is the contributor guide for AI agents (and humans!) modifying this repo. T
 - `nsc/model/` — the normalized command tree (data only, framework-free). The "brain".
 - `nsc/builder/` — converts a parsed schema into a `CommandModel`.
 - `nsc/cli/` — the Typer app; consumes a `CommandModel`.
-- `nsc/http/` — thin httpx wrapper (Phase 2+).
-- `nsc/output/` — formatters (Phase 2+).
-- `nsc/config/` — config loader + Pydantic models (Phase 1 has a minimal version).
+- `nsc/http/` — thin httpx wrapper: auth, retries, audit log.
+- `nsc/output/` — formatters (table/json/jsonl/yaml/csv) + error envelope.
+- `nsc/config/` — config loader + Pydantic models + ruamel.yaml round-trip writer.
 - `nsc/cache/` — disk cache for generated command-models.
+- `nsc/auth/` — login verification helpers (pre-flight probes, token rotate).
+- `nsc/aliases/` — curated alias resolver (`ls`, `get`, `rm`, `search`). Framework-free.
+- `nsc/skill/` — bundle-path helper for the portable `SKILL.md` shipped in the wheel.
 - `nsc/schemas/bundled/` — versioned NetBox OpenAPI snapshots, fallback when offline.
 
 The hard rule: **`nsc/model/` imports nothing from `nsc/cli/`, `nsc/http/`, or any framework.** If you need to add a dependency to `model/`, you're probably solving the wrong problem.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ A Python CLI for [NetBox](https://netbox.dev/) that builds its command tree dyna
 - **Safe by default.** POST/PATCH/PUT/DELETE preview as dry-runs unless you pass `--apply`.
 - **Agent-friendly.** Deterministic command shape, machine-readable JSON output, stable error envelope with documented exit codes.
 
-## Install (preview)
+## Install
 
 ```
+pip install netbox-super-cli
+# or, if you use uv:
 uv tool install netbox-super-cli
 ```
 
-Not on PyPI yet; install from source:
+Or from source:
 ```
 git clone https://github.com/thomaschristory/netbox-super-cli
 cd netbox-super-cli
@@ -85,7 +87,7 @@ Stdin is sniffed from the first 512 bytes (first non-whitespace byte plus a one-
 - HTTP headers in the `SENSITIVE_HEADERS` set (e.g. `Authorization`, `X-API-Key`) — replaced with `"<redacted>"`.
 - Request-body fields whose OpenAPI definition has `format: password` OR whose name (case-insensitive) is one of: `password`, `secret`, `token`, `api_key`, `apikey`, `private_key`, `passphrase`, `client_secret`. Nested fields and arrays of objects are walked recursively.
 
-The wire body sent to NetBox is **not** redacted — only the audit log. A failed write still records the redacted body; redaction is irreversible. Treat `audit.jsonl` like a verbose application log: gate it behind your home-directory permissions and rotate / archive accordingly. A "redact everything" mode is deferred to Phase 5+.
+The wire body sent to NetBox is **not** redacted — only the audit log. A failed write still records the redacted body; redaction is irreversible. Treat `audit.jsonl` like a verbose application log: gate it behind your home-directory permissions and rotate / archive accordingly. A "redact everything" mode is on the post-v1.0 roadmap.
 
 ## Output and errors
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A Python CLI for [NetBox](https://netbox.dev/) that builds its command tree dyna
 ## Install
 
 ```
-pip install netbox-super-cli
-# or, if you use uv:
 uv tool install netbox-super-cli
+# or, with pipx:
+pipx install netbox-super-cli
 ```
 
 Or from source:

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -26,7 +26,7 @@ one-line "schema changed, regenerating…" notice on stderr.
 
 ## Cleaning up
 
-`nsc cache prune` (Phase 5a) handles three classes of orphan:
+`nsc cache prune` handles three classes of orphan:
 
 1. Profile directories not in `~/.nsc/config.yaml` (e.g., a removed profile).
 2. `<schema_hash>.json` files inside an active profile whose hash no longer

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -23,12 +23,33 @@ publishes to PyPI via trusted publishing (no API tokens).
 
 Each planned release has a milestone named after its version (e.g., `v1.1.0`).
 Issues and PRs are triaged to a milestone when they are scoped to a specific
-release. At release time, close the milestone; open issues are either
-bumped to the next milestone or moved to the backlog.
+release. Milestones are purely organizational — they don't trigger anything.
 
 - Milestone name: `vX.Y.Z` (matches the git tag exactly).
 - An open milestone with no due date means "planned but not scheduled".
 - The `main` branch is always releasable; milestones are a planning aid, not a gate.
+
+**When a release ships, open the next milestone.** A milestone is considered
+closed once its release is published to PyPI and tagged on GitHub. As part
+of finalizing the release:
+
+1. Close the milestone:
+   ```sh
+   gh api repos/:owner/:repo/milestones/<N> -X PATCH -f state=closed
+   ```
+2. Open the next one:
+   ```sh
+   gh api repos/:owner/:repo/milestones -f title='v<next>' -f state=open
+   ```
+   For a patch release, increment the patch number; for a minor/major,
+   pick whatever's next based on what's queued.
+3. Bump or close any open issues left in the just-closed milestone — either
+   move them to the next milestone or drop them to the backlog.
+4. Leave the new milestone otherwise empty — issues get attached as they're
+   triaged.
+
+This keeps a milestone always available to file new issues against without
+having to think about it mid-bug-report.
 
 ## Patch releases (bug fixes)
 
@@ -56,4 +77,6 @@ From v1.0.0 onward:
 - `MAJOR` — breaking changes to the error envelope, exit codes, or config schema.
 
 The version in `pyproject.toml`, `nsc/_version.py`, and the git tag must
-always agree. `release.yml` validates this before publishing.
+always agree. `release.yml` validates the tag against `nsc/_version.py`
+before publishing; `pyproject.toml` is not currently checked, so keep it
+in sync manually as part of the release commit.

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -1,42 +1,59 @@
 # Release process
 
-Releases are tag-driven. Each phase's sub-phases ship as `vX.Y.Z<a|b|c|d>`;
-the final cut of a phase drops the suffix (e.g., `v0.5.0` is Phase 5d).
+`nsc` follows [Semantic Versioning](https://semver.org/) from v1.0.0 onward.
+Releases are tag-driven: `release.yml` fires on `v*.*.*` tag pushes and
+publishes to PyPI via trusted publishing (no API tokens).
 
-## Sub-phase release checklist
-
-For a sub-phase tag like `v0.5.0b`:
+## Normal release checklist
 
 1. Full unit suite green: `just test`.
 2. Lint clean: `just lint`.
-3. Bench median <300ms: `just bench`.
-4. E2E green (against the live container): `just e2e` (requires Docker).
-5. CHANGELOG `[Unreleased]` rolled to `[v0.5.0b] — YYYY-MM-DD`.
-6. Tag annotated: `git tag -a v0.5.0b -m "Phase 5b: ..."`.
-7. Push: `git push origin main && git push origin v0.5.0b`.
-8. Watch CI: `gh run list --branch main --limit 4`.
+3. Bench median <300 ms: `just bench`.
+4. E2E green (requires Docker): `just e2e`.
+5. Roll `CHANGELOG.md`: move `[Unreleased]` to `[vX.Y.Z] — YYYY-MM-DD`.
+6. Bump `pyproject.toml` `[project].version` and `nsc/_version.py` `__version__`
+   to match the tag.
+7. Close the matching [GitHub milestone](https://github.com/thomaschristory/netbox-super-cli/milestones)
+   and verify all tracked issues are resolved or deferred.
+8. Commit: `git commit -m "chore(release): X.Y.Z"`.
+9. Annotate and push: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin main vX.Y.Z`.
+10. Watch `release.yml` publish the wheel and create the GitHub Release.
 
-## Final v1.0.0 release
+## GitHub milestones convention
 
-Phase 5d cuts v1.0.0. The release pipeline:
+Each planned release has a milestone named after its version (e.g., `v1.1.0`).
+Issues and PRs are triaged to a milestone when they are scoped to a specific
+release. At release time, close the milestone; open issues are either
+bumped to the next milestone or moved to the backlog.
 
-1. `pyproject.toml` version bump from `0.0.1` to `1.0.0`.
-2. Trusted publishing configured on PyPI (one-time, manual; see PyPI's
-   "Publishing" tab).
-3. `release.yml` workflow runs on `v*` tag push: `uv build` →
-   `pypa/gh-action-pypi-publish` → `gh release create` with auto-generated
-   notes from `CHANGELOG.md`.
-4. `agents-md-sync.yml` regenerates `AGENTS.md` from `CLAUDE.md`.
-5. Phase 6+ GitHub issues filed for every deferred item (keyring, dynamic
-   completion, concurrency, multi-NetBox-version CI matrix, stricter
-   redaction, singular aliases, Skill install drift).
+- Milestone name: `vX.Y.Z` (matches the git tag exactly).
+- An open milestone with no due date means "planned but not scheduled".
+- The `main` branch is always releasable; milestones are a planning aid, not a gate.
+
+## Patch releases (bug fixes)
+
+Patch bumps (`Z` increment) follow the same checklist. Because they contain
+only bug fixes, the E2E run can be skipped if the fix is confined to a code
+path not exercised by the E2E suite — but running it is still recommended.
+
+## Minor / major releases
+
+Minor (`Y`) or major (`X`) bumps follow the full checklist. Before tagging,
+open a tracking issue or milestone for any follow-on items deferred from the
+release.
 
 ## Hot-fixing a tagged release
 
-Don't amend a tagged commit. Cut a fresh `vX.Y.Z<suffix>-fix1` tag with the
-fix and document in the next sub-phase's plan.
+Never amend a tagged commit. Cut a `vX.Y.Z+1` patch release with the fix
+and document it in `CHANGELOG.md` under a new `[vX.Y.Z+1]` entry.
 
 ## Versioning policy
 
-Phase milestones are pinned by git tags rather than `pyproject.toml` version
-bumps while pre-1.0. After v1.0.0, semver applies.
+From v1.0.0 onward:
+
+- `PATCH` — backwards-compatible bug fixes.
+- `MINOR` — new backwards-compatible features or CLI commands.
+- `MAJOR` — breaking changes to the error envelope, exit codes, or config schema.
+
+The version in `pyproject.toml`, `nsc/_version.py`, and the git tag must
+always agree. `release.yml` validates this before publishing.

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -13,38 +13,43 @@ publishes to PyPI via trusted publishing (no API tokens).
 5. Roll `CHANGELOG.md`: move `[Unreleased]` to `[vX.Y.Z] — YYYY-MM-DD`.
 6. Bump `pyproject.toml` `[project].version` and `nsc/_version.py` `__version__`
    to match the tag.
-7. Close the matching [GitHub milestone](https://github.com/thomaschristory/netbox-super-cli/milestones)
-   and verify all tracked issues are resolved or deferred.
+7. Verify all issues attached to the matching
+   [GitHub milestone](https://github.com/thomaschristory/netbox-super-cli/milestones)
+   are resolved or deferred (don't close the milestone yet — that happens
+   after publish, see below).
 8. Commit: `git commit -m "chore(release): X.Y.Z"`.
 9. Annotate and push: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin main vX.Y.Z`.
 10. Watch `release.yml` publish the wheel and create the GitHub Release.
+11. Once PyPI shows the new version and the GitHub Release is live, close
+    the milestone and open the next one — see the next section for the
+    exact `gh api` invocations.
 
 ## GitHub milestones convention
 
 Each planned release has a milestone named after its version (e.g., `v1.1.0`).
 Issues and PRs are triaged to a milestone when they are scoped to a specific
-release. Milestones are purely organizational — they don't trigger anything.
+release. Milestones don't gate CI — they're a planning aid that surfaces
+what's queued for which version.
 
 - Milestone name: `vX.Y.Z` (matches the git tag exactly).
 - An open milestone with no due date means "planned but not scheduled".
-- The `main` branch is always releasable; milestones are a planning aid, not a gate.
+- The `main` branch is always releasable; milestones don't block merges.
 
-**When a release ships, open the next milestone.** A milestone is considered
-closed once its release is published to PyPI and tagged on GitHub. As part
-of finalizing the release:
+**Once a release is published**, close its milestone and open the next one.
+This is step 11 of the release checklist; the exact commands are:
 
-1. Close the milestone:
+1. Bump or close any open issues left in the just-shipped milestone —
+   either move them to the next milestone or drop them to the backlog.
+2. Close the milestone:
    ```sh
    gh api repos/:owner/:repo/milestones/<N> -X PATCH -f state=closed
    ```
-2. Open the next one:
+3. Open the next one:
    ```sh
    gh api repos/:owner/:repo/milestones -f title='v<next>' -f state=open
    ```
    For a patch release, increment the patch number; for a minor/major,
    pick whatever's next based on what's queued.
-3. Bump or close any open issues left in the just-closed milestone — either
-   move them to the next milestone or drop them to the backlog.
 4. Leave the new milestone otherwise empty — issues get attached as they're
    triaged.
 
@@ -65,8 +70,9 @@ release.
 
 ## Hot-fixing a tagged release
 
-Never amend a tagged commit. Cut a `vX.Y.Z+1` patch release with the fix
-and document it in `CHANGELOG.md` under a new `[vX.Y.Z+1]` entry.
+Never amend a tagged commit. Increment the patch component (e.g.,
+`v1.0.1` → `v1.0.2`), cut a fresh patch release with the fix, and document
+it in `CHANGELOG.md` under a new `[vX.Y.Z]` entry for the new version.
 
 ## Versioning policy
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -15,8 +15,6 @@ pipx install netbox-super-cli
 uv tool install netbox-super-cli
 ```
 
-> **Phase 5b note:** the PyPI release lands in Phase 5d. Until then, install from source (see below).
-
 Verify the install:
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,6 @@ Dynamic NetBox CLI driven by the live OpenAPI schema. The same `nsc` binary work
 against any NetBox version (4.4+) and exposes plugin-provided endpoints automatically
 because the schema — not hand-written code — defines the surface.
 
-> **Status:** Phase 5b. v1.0.0 publish lands in 5d. Until then, install from source.
-
 ## Why nsc
 
 - **Plugins just work.** New endpoints from any installed plugin appear as commands automatically.

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -65,7 +65,7 @@ Errors come back as JSON envelopes (on stderr by default; on stdout when
 ```json
 {
   "error": "human-readable message",
-  "type": "auth | not_found | validation | conflict | rate_limited | server | transport | schema | config | client | internal | input_error | …",
+  "type": "auth | not_found | validation | conflict | rate_limited | server | transport | schema | config | client | internal | input_error | ambiguous_alias | unknown_alias",
   "endpoint": "/api/dcim/devices/",
   "method": "POST",
   "status_code": 400,

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -47,9 +47,9 @@ nsc dcim devices create -f device.yaml          # dry-run; prints what would hap
 nsc dcim devices create -f device.yaml --apply  # actually creates
 ```
 
-Bulk writes accept `--ndjson <file>` (one JSON object per line) and the same
-`--apply` rule applies. Read commands (`list`, `get`, `describe`) ignore
-`--apply` — never paste it into a read by reflex.
+Bulk writes use `-f <file>` with a `.ndjson` / `.jsonl` extension (one JSON
+object per line) and the same `--apply` rule applies. Read commands (`list`,
+`get`, `describe`) ignore `--apply` — never paste it into a read by reflex.
 
 ## Stable JSON output
 
@@ -65,7 +65,7 @@ Errors come back as JSON envelopes (on stderr by default; on stdout when
 ```json
 {
   "error": "human-readable message",
-  "type": "validation | http | client | server | schema | …",
+  "type": "auth | not_found | validation | conflict | rate_limited | server | transport | schema | config | client | internal | input_error | …",
   "endpoint": "/api/dcim/devices/",
   "method": "POST",
   "status_code": 400,
@@ -84,7 +84,7 @@ the project's `reference/exit-codes.md` page.
 - **List with filters:** `nsc dcim devices list --site mysite --status active --output json`
 - **Get one:** `nsc dcim devices get 42 --output json`
 - **Create from a YAML file:** `nsc dcim devices create -f new-device.yaml --apply`
-- **Bulk create from NDJSON:** `nsc dcim devices create --ndjson devices.ndjson --apply`
+- **Bulk create from NDJSON:** `nsc dcim devices create -f devices.ndjson --apply`
 - **Update a field:** `nsc dcim devices update 42 --status decommissioning --apply`
 - **Delete:** `nsc dcim devices delete 42 --apply` (preview first WITHOUT `--apply`)
 


### PR DESCRIPTION
Post-v1.0.0 documentation pass addressing stale content identified in #25.

## Changes

- **README**: drop "(preview)" heading, fix install section (PyPI is live), soften "Phase 5+" deferral note to "post-v1.0 roadmap".
- **docs/index.md**: remove Phase 5b status banner.
- **docs/getting-started/install.md**: remove stale Phase 5b PyPI note.
- **docs/architecture/caching.md**: drop "(Phase 5a)" parenthetical from `nsc cache prune`.
- **CLAUDE.md / AGENTS.md**: expand architecture cheat-sheet with `auth/`, `aliases/`, `skill/`; flesh out `http/`, `output/`, `config/` descriptions; remove phase markers.
- **docs/contributing/release-process.md**: rewrite for post-v1.0.0 semver workflow; add a GitHub milestones convention section.
- **skills/netbox-super-cli/SKILL.md**: fix bulk-write syntax (`-f file.ndjson` instead of the removed `--ndjson` flag); expand error type list to match `ErrorType` enum.

Closes #25.