### PR TITLE
feat(init): prompt for verify_ssl during first-run wizard

### DIFF
--- a/nsc/cli/init_commands.py
+++ b/nsc/cli/init_commands.py
@@ -46,12 +46,15 @@ def _build_doc(
     profile_name: str,
     url: str,
     token_value: object,
+    verify_ssl: bool = True,
 ) -> CommentedMap:
     """Produce the minimal config doc for a fresh init run."""
     profiles = CommentedMap()
     profile = CommentedMap()
     profile["url"] = url
     profile["token"] = token_value
+    if not verify_ssl:
+        profile["verify_ssl"] = False
     profiles[profile_name] = profile
 
     doc = CommentedMap()
@@ -78,6 +81,7 @@ def register(app: typer.Typer) -> None:
 
         profile_name = typer.prompt("Profile name", default="default")
         url = typer.prompt("NetBox URL (e.g. https://netbox.example.com/)")
+        verify_ssl = typer.confirm("Verify SSL certificates?", default=True)
         storage = typer.prompt("Token storage [plaintext|env]", default="plaintext").strip().lower()
         token_value: object
         if storage == "env":
@@ -86,7 +90,7 @@ def register(app: typer.Typer) -> None:
         else:
             token_value = typer.prompt("Token", hide_input=True)
 
-        doc = _build_doc(profile_name.strip(), url.strip(), token_value)
+        doc = _build_doc(profile_name.strip(), url.strip(), token_value, verify_ssl=verify_ssl)
 
         with acquire_lock(path):
             atomic_write(path, dump_round_trip(doc))

--- a/nsc/cli/init_commands.py
+++ b/nsc/cli/init_commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import click
 import typer
 from ruamel.yaml.comments import CommentedMap, TaggedScalar
 
@@ -79,16 +80,21 @@ def register(app: typer.Typer) -> None:
             )
             raise typer.Exit(code=12)
 
-        profile_name = typer.prompt("Profile name", default="default")
-        url = typer.prompt("NetBox URL (e.g. https://netbox.example.com/)")
-        verify_ssl = typer.confirm("Verify SSL certificates?", default=True)
-        storage = typer.prompt("Token storage [plaintext|env]", default="plaintext").strip().lower()
-        token_value: object
-        if storage == "env":
-            var_name = typer.prompt("Environment variable name (e.g. NSC_PROD_TOKEN)")
-            token_value = _env_tagged(var_name.strip())
-        else:
-            token_value = typer.prompt("Token", hide_input=True)
+        try:
+            profile_name = typer.prompt("Profile name", default="default")
+            url = typer.prompt("NetBox URL (e.g. https://netbox.example.com/)")
+            verify_ssl = typer.confirm("Verify SSL certificates?", default=True)
+            raw_storage = typer.prompt("Token storage [plaintext|env]", default="plaintext")
+            storage = raw_storage.strip().lower()
+            token_value: object
+            if storage == "env":
+                var_name = typer.prompt("Environment variable name (e.g. NSC_PROD_TOKEN)")
+                token_value = _env_tagged(var_name.strip())
+            else:
+                token_value = typer.prompt("Token", hide_input=True)
+        except click.Abort:
+            typer.echo("\nerror: init wizard aborted; re-run `nsc init` to try again.", err=True)
+            raise typer.Exit(code=1) from None
 
         doc = _build_doc(profile_name.strip(), url.strip(), token_value, verify_ssl=verify_ssl)
 

--- a/tests/cli/test_init_commands.py
+++ b/tests/cli/test_init_commands.py
@@ -8,6 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nsc.cli.app import app
+from nsc.config.loader import load_config
 
 
 @pytest.fixture
@@ -107,3 +108,21 @@ def test_init_with_verify_ssl_false_writes_verify_ssl(home: Path) -> None:
     assert result.exit_code == 0, result.stdout + result.stderr
     body = (home / "config.yaml").read_text(encoding="utf-8")
     assert "verify_ssl: false" in body
+    cfg = load_config(home / "config.yaml")
+    assert cfg.profiles["prod"].verify_ssl is False
+
+
+def test_init_env_token_with_verify_ssl_false(home: Path) -> None:
+    """env token storage combined with verify_ssl=false produces both fields correctly."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["init"],
+        input="prod\nhttps://nb.example/\nn\nenv\nNSC_PROD_TOKEN\n",
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    body = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "token: !env NSC_PROD_TOKEN" in body
+    assert "verify_ssl: false" in body
+    cfg = load_config(home / "config.yaml")
+    assert cfg.profiles["prod"].verify_ssl is False

--- a/tests/cli/test_init_commands.py
+++ b/tests/cli/test_init_commands.py
@@ -21,11 +21,11 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def test_init_writes_minimal_config_on_clean_home(home: Path) -> None:
     runner = CliRunner()
-    # Stdin order: profile name, URL, token storage choice, token literal.
+    # Stdin order: profile name, URL, verify_ssl (default Y), token storage choice, token literal.
     result = runner.invoke(
         app,
         ["init"],
-        input="prod\nhttps://nb.example/\nplaintext\nabcd1234\n",
+        input="prod\nhttps://nb.example/\n\nplaintext\nabcd1234\n",
     )
     assert result.exit_code == 0, result.stdout + result.stderr
     body = (home / "config.yaml").read_text(encoding="utf-8")
@@ -39,7 +39,7 @@ def test_init_with_env_token_storage_writes_env_tag(home: Path) -> None:
     result = runner.invoke(
         app,
         ["init"],
-        input="prod\nhttps://nb.example/\nenv\nNSC_PROD_TOKEN\n",
+        input="prod\nhttps://nb.example/\n\nenv\nNSC_PROD_TOKEN\n",
     )
     assert result.exit_code == 0, result.stdout + result.stderr
     body = (home / "config.yaml").read_text(encoding="utf-8")
@@ -77,7 +77,33 @@ def test_init_treats_empty_existing_config_as_clean(home: Path) -> None:
     result = runner.invoke(
         app,
         ["init"],
-        input="prod\nhttps://nb.example/\nplaintext\nabcd1234\n",
+        input="prod\nhttps://nb.example/\n\nplaintext\nabcd1234\n",
     )
     assert result.exit_code == 0, result.stdout + result.stderr
     assert "default_profile: prod" in (home / "config.yaml").read_text(encoding="utf-8")
+
+
+def test_init_defaults_verify_ssl_to_true_and_omits_from_config(home: Path) -> None:
+    """Accepting the default (Y) keeps the config minimal — verify_ssl is not written."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["init"],
+        input="prod\nhttps://nb.example/\ny\nplaintext\nabcd1234\n",
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    body = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "verify_ssl" not in body
+
+
+def test_init_with_verify_ssl_false_writes_verify_ssl(home: Path) -> None:
+    """Answering 'n' to verify SSL writes `verify_ssl: false` to the profile."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["init"],
+        input="prod\nhttps://nb.example/\nn\nplaintext\nabcd1234\n",
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    body = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "verify_ssl: false" in body


### PR DESCRIPTION
## Summary

- Adds a `Verify SSL certificates?` confirm prompt to `nsc init` (defaults `Y`)
- Only writes `verify_ssl: false` to the profile when the user opts out — keeps configs minimal by default
- Updates existing test inputs to account for the new prompt position
- Adds two regression tests: default omits the key, explicit `n` writes `verify_ssl: false`

Closes #22

## Test plan

- [ ] `just test` passes
- [ ] `nsc init` (fresh) prompts for SSL verification after URL entry
- [ ] Accepting default produces a config with no `verify_ssl` key
- [ ] Answering `n` produces `verify_ssl: false` in the profile block

🤖 Generated with [Claude Code](https://claude.com/claude-code)