### PR TITLE
docs: normalize LICENSE to apache.org canonical text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -32,10 +33,10 @@
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-      "Work" shall mean the work of authorship, whether in Source or Object
-      form, made available under the License, as indicated by a copyright
-      notice that is included in or attached to the work (an example is
-      provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
@@ -155,7 +156,7 @@
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
       liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a
+      incidental, or consequential damages of any character arising as a
       result of this License or out of the use or inability to use the
       Work (including but not limited to damages for loss of goodwill,
       work stoppage, computer failure or malfunction, or any and all
@@ -163,12 +164,12 @@
       has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, you may choose to offer,
+      the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, you may act only
-      on your own behalf and on your sole responsibility, not on behalf
-      of any other Contributor, and only if you agree to indemnify,
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.


### PR DESCRIPTION
## Summary

Replaces the legacy Apache 2.0 variant (shipped since v1.0.0) with the current canonical text from https://www.apache.org/licenses/LICENSE-2.0.txt.

Three textual differences resolved per the issue description:
- **Section 8**: `exemplary damages` → `consequential damages`
- **Section 1** ("Work" definition): paragraph re-wrapped to match canonical 4-line form
- **Section 9**: lowercase `you/your` → `You/Your` (consistent capitalization with rest of document)
- Leading blank line added (canonical file is now 202 lines, matching apache.org)

SPDX identifier in `pyproject.toml` (`Apache-2.0`) is unchanged — this is a text normalization only.

Closes #18

## Test plan
- [ ] `diff <(curl -s https://www.apache.org/licenses/LICENSE-2.0.txt) LICENSE` produces no output
- [ ] CI passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)