### PR TITLE
feat(schema): TTL fast-path skips per-invocation /api/schema/ fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to netbox-super-cli are tracked here. Format follows [Keep a
 
 ## Unreleased
 
+### Added
+
+- **Schema TTL fast-path** (issue #34). `nsc` now skips the per-invocation `GET /api/schema/` round-trip when a sidecar-validated cache entry is fresh. Freshness is tracked in `~/.nsc/cache/<profile>/<hash>.meta.json` (an explicit `fetched_at` timestamp), not file mtime — so `touch`, backup-restore, or `cp -p` can't fake freshness, and clocks that jumped forward then back are rejected (>60s skew distrusted).
+- **`nsc --refresh-schema <subcmd>`** — one-shot forced refresh that bypasses the TTL even on `daily`/`weekly`/`manual` policies. Use after a NetBox upgrade to pick up a new schema immediately without changing config.
+- Atomic cache writes — `CacheStore.save` now writes via temp-file + `os.replace`, so a concurrent `nsc` reader can never observe a partial cache file.
+
+### Changed
+
+- **Default `defaults.schema_refresh` is now `daily`** (was `on-hash-change`). This is the user-visible behaviour change behind the fast-path: under the new default, `nsc` trusts a cached schema for 24h. **If you need the v1.0.1 behaviour** (re-fetch every invocation to detect a schema change immediately), set `defaults.schema_refresh: on-hash-change` in `~/.nsc/config.yaml`. To force a one-shot refresh under any policy, prepend `--refresh-schema` to the command. Existing configs with an explicit `schema_refresh` value are unaffected.
+- Cache files written before this release have no sidecar and will be treated as stale on first invocation after upgrade — `nsc` refetches once, writes the sidecar, and the fast-path is active from there.
+
 ## v1.0.1 — 2026-05-06
 
 First patch release. Two bug fixes; no API or behavior changes elsewhere.

--- a/docs/architecture/schema-loading.md
+++ b/docs/architecture/schema-loading.md
@@ -4,29 +4,57 @@
 
 ## Resolution order
 
-Highest priority first:
+Highest priority first, given the active `defaults.schema_refresh` policy
+and an optional `--refresh-schema` override:
 
-1. `--schema <path-or-url>` — one-shot override.
-2. Active profile's `schema_url` (explicit) or `{profile.url}/api/schema/?format=json`.
-3. Cached generated command-model at `~/.nsc/cache/<profile>/<schema-hash>.json`
-   if its hash matches the live schema.
-4. Bundled snapshot at `nsc/schemas/bundled/netbox-<closest-version>.json` (in
-   the wheel) — last-resort offline fallback.
+1. `--schema <path-or-url>` — one-shot override. Always wins; never
+   consults the TTL fast-path or the network.
+2. **TTL fast-path.** If the policy is `daily`, `weekly`, or `manual` and
+   the newest sidecar-validated cache entry for the active profile is
+   fresher than the policy's TTL, `nsc` returns it directly with no HTTP
+   round-trip. Skipped when `--refresh-schema` is passed (or the policy
+   is `on-hash-change`).
+3. Live fetch from the active profile's `schema_url` (explicit) or
+   `{profile.url}/api/schema/?format=json`. The fetched body is hashed;
+   if a cache file already exists at that hash it's loaded directly,
+   otherwise the command-model is rebuilt and saved.
+4. On fetch failure: any cached entry for the profile (warns once on
+   stderr).
+5. Bundled snapshot at `nsc/schemas/bundled/netbox-<closest-version>.json`
+   (shipped in the wheel) — last-resort offline fallback.
 
 ## Hashing
 
-The cache key is `sha256` of the canonicalized schema body (JSON re-serialized
-with sorted keys, no whitespace). This means cosmetic changes to the upstream
-schema (whitespace, key order) don't bust the cache, but any semantic change
-(new endpoint, changed field) does.
+The cache key is `sha256` of the canonicalized schema body (JSON
+re-serialized with sorted keys, no whitespace). Cosmetic changes to the
+upstream schema (whitespace, key order) don't bust the cache, but any
+semantic change (new endpoint, changed field) does.
+
+## Cache layout
+
+Each profile has a directory under `~/.nsc/cache/<profile>/` containing,
+per schema hash:
+
+- `<hash>.json` — the generated `CommandModel`. Loaded via
+  `CacheStore.load`, which re-verifies that the file's embedded
+  `schema_hash` matches the filename — so a tampered or copied JSON
+  file is rejected.
+- `<hash>.meta.json` — a sidecar with `{"fetched_at": <epoch_seconds>}`.
+  Drives the TTL fast-path. Written atomically alongside the cache file
+  via temp-file + `os.replace`.
+
+A sidecar dated more than 60s in the future (clock skew or tampering)
+is rejected. A cache entry without its sidecar is treated as stale —
+that's the upgrade path for caches written before sidecars existed.
 
 ## Offline behavior
 
-- Live schema unreachable + cache present → use cache, warn once on stderr.
-- Live schema unreachable + no cache → fall back to closest bundled version,
-  warn loudly.
-- Errors include a remediation hint ("run `nsc refresh` when the instance is
-  reachable").
+- Live schema unreachable + cache present → use cache, warn once on
+  stderr.
+- Live schema unreachable + no cache → fall back to the closest bundled
+  version, warn loudly.
+- All such errors include a remediation hint pointing at
+  `--refresh-schema` for once the instance is reachable again.
 
 ## Refresh modes
 
@@ -34,13 +62,23 @@ In `~/.nsc/config.yaml`:
 
 ```yaml
 defaults:
-  schema_refresh: on-hash-change   # default
+  schema_refresh: daily   # default since the v1.0.2 release line
 ```
 
-Other values: `manual`, `daily`, `weekly`. `manual` means the cache is never
-auto-invalidated — you must call `nsc refresh` explicitly.
+| Value            | TTL    | Behaviour                                                       |
+|------------------|--------|-----------------------------------------------------------------|
+| `daily`          | 24h    | Default. Trust a fresh cache; re-fetch once a day.              |
+| `weekly`         | 7d     | Trust longer; suitable for stable NetBox deployments.           |
+| `manual`         | ∞      | Never auto-invalidate. Use `--refresh-schema` to update.        |
+| `on-hash-change` | 0      | v1.0.1 behaviour: re-fetch every invocation, compare hashes.    |
+
+Use `nsc --refresh-schema <subcommand>` to force a one-shot refresh
+that bypasses the TTL fast-path under any policy.
 
 ## When you change NetBox versions
 
-The hash changes → next invocation regenerates the model in the background.
-The old `<old_hash>.json` becomes orphan and gets cleaned by `nsc cache prune`.
+The hash changes → next invocation that bypasses the fast-path
+regenerates the model. Under `daily` (the default) you may need to
+prepend `--refresh-schema` to your first post-upgrade invocation, or
+wait up to 24h. The old `<old_hash>.json` (and its sidecar) become
+orphaned and get cleaned by `nsc cache prune`.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -11,7 +11,7 @@ All fields below describe `~/.nsc/config.yaml`.
 |---|---|---|
 | `default_profile` | `str | None` | `None` |
 | `profiles` | `dict[str, Profile]` | `{}` |
-| `defaults` | `<class 'Defaults'>` | `Defaults(output=<OutputFormat.TABLE: 'table'>, page_size=50, timeout=30.0, schema_refresh=<SchemaRefresh.ON_HASH_CHANGE: 'on-hash-change'>)` |
+| `defaults` | `<class 'Defaults'>` | `Defaults(output=<OutputFormat.TABLE: 'table'>, page_size=50, timeout=30.0, schema_refresh=<SchemaRefresh.DAILY: 'daily'>)` |
 | `columns` | `dict[str, dict[str, list[str]]]` | `{}` |
 
 ## `Profile`
@@ -32,4 +32,4 @@ All fields below describe `~/.nsc/config.yaml`.
 | `output` | `<enum 'OutputFormat'>` | `<OutputFormat.TABLE: 'table'>` |
 | `page_size` | `<class 'int'>` | `50` |
 | `timeout` | `<class 'float'>` | `30.0` |
-| `schema_refresh` | `<enum 'SchemaRefresh'>` | `<SchemaRefresh.ON_HASH_CHANGE: 'on-hash-change'>` |
+| `schema_refresh` | `<enum 'SchemaRefresh'>` | `<SchemaRefresh.DAILY: 'daily'>` |

--- a/nsc/cache/store.py
+++ b/nsc/cache/store.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -80,8 +82,32 @@ class CacheStore:
         self._validate_profile(profile)
         target = self._path_for(profile, model.schema_hash)
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(model.model_dump_json(indent=2))
+        _atomic_write(target, model.model_dump_json(indent=2))
+        meta = self._meta_path_for(profile, model.schema_hash)
+        _atomic_write(meta, json.dumps({"fetched_at": time.time()}))
         return target
+
+    def load_fetched_at(self, profile: str, schema_hash: str) -> float | None:
+        """Return epoch seconds when this cache entry was last fetched, or
+        `None` if the sidecar is missing/unreadable. Used by the TTL
+        fast-path so freshness is keyed off an explicit fetch timestamp
+        rather than the cache file's mtime (which can be touched, restored
+        from backup, or skewed by clock drift)."""
+        self._validate_profile(profile)
+        if not _HASH_RE.match(schema_hash):
+            return None
+        meta = self._meta_path_for(profile, schema_hash)
+        if not meta.exists():
+            return None
+        try:
+            data = json.loads(meta.read_text())
+        except Exception as exc:
+            _LOG.warning("cache: ignoring corrupt sidecar %s (%s)", meta, exc)
+            return None
+        value = data.get("fetched_at") if isinstance(data, dict) else None
+        if not isinstance(value, (int, float)):
+            return None
+        return float(value)
 
     def clear(self, *, profile: str | None = None) -> None:
         if profile is None:
@@ -149,10 +175,23 @@ class CacheStore:
     def _path_for(self, profile: str, schema_hash: str) -> Path:
         return self.root / profile / f"{schema_hash}.json"
 
+    def _meta_path_for(self, profile: str, schema_hash: str) -> Path:
+        return self.root / profile / f"{schema_hash}.meta.json"
+
     @staticmethod
     def _validate_profile(profile: str) -> None:
         if not _PROFILE_RE.match(profile):
             raise ValueError(f"invalid profile name {profile!r}: must match {_PROFILE_RE.pattern}")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write `content` to `path` via temp-file + `os.replace` so that a
+    concurrent reader either sees the previous file or the new one — never
+    a partial write. Same-directory temp guarantees `replace` is atomic on
+    POSIX and Windows."""
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
 
 
 ADHOC_PROFILE = "adhoc"
@@ -287,6 +326,11 @@ def prune_orphans(plan: PrunePlan) -> PruneResult:
             freed += f.stat().st_size
             f.unlink()
             deleted_files += 1
+        sidecar = f.with_name(f"{f.stem}.meta.json")
+        if sidecar.exists():
+            with contextlib.suppress(FileNotFoundError):
+                freed += sidecar.stat().st_size
+                sidecar.unlink()
 
     return PruneResult(
         deleted_dirs=deleted_dirs,

--- a/nsc/cli/app.py
+++ b/nsc/cli/app.py
@@ -84,6 +84,10 @@ def _extract_global_overrides(args: list[str]) -> CLIOverrides:
             kwargs["insecure"] = False
             i += 1
             continue
+        if a == "--refresh-schema":
+            kwargs["refresh_schema"] = True
+            i += 1
+            continue
         i += 1
     return CLIOverrides(**kwargs)  # type: ignore[arg-type]
 
@@ -225,6 +229,13 @@ def _root(
     token: Annotated[str | None, typer.Option("--token")] = None,
     insecure: Annotated[bool | None, typer.Option("--insecure/--no-insecure")] = None,
     schema: Annotated[str | None, typer.Option("--schema")] = None,
+    refresh_schema: Annotated[
+        bool,
+        typer.Option(
+            "--refresh-schema",
+            help="Force a fresh /api/schema/ fetch, bypassing the cache TTL.",
+        ),
+    ] = False,
     output: Annotated[str | None, typer.Option("--output", "-o")] = None,
     debug: Annotated[bool, typer.Option("--debug")] = False,
 ) -> None:
@@ -235,6 +246,7 @@ def _root(
         token=token,
         insecure=insecure,
         schema_override=schema,
+        refresh_schema=refresh_schema,
         output=output,
     )
     try:

--- a/nsc/cli/globals.py
+++ b/nsc/cli/globals.py
@@ -33,7 +33,11 @@ def build_runtime_context(state: GlobalState) -> RuntimeContext:
     profile = resolve_profile(state.config, state.overrides, env=os.environ)
     paths = default_paths()
     model = resolve_command_model(
-        paths=paths, profile=profile, schema_override=state.overrides.schema_override
+        paths=paths,
+        profile=profile,
+        schema_override=state.overrides.schema_override,
+        schema_refresh=state.config.defaults.schema_refresh,
+        force_refresh=state.overrides.refresh_schema,
     )
     output = select_format(
         cli_value=state.overrides.output,

--- a/nsc/cli/runtime.py
+++ b/nsc/cli/runtime.py
@@ -51,6 +51,7 @@ class CLIOverrides(_Frozen):
     token: str | None = None
     insecure: bool | None = None
     schema_override: str | None = None
+    refresh_schema: bool = False
     output: str | None = None
 
 

--- a/nsc/config/models.py
+++ b/nsc/config/models.py
@@ -35,7 +35,7 @@ class Defaults(_Frozen):
     output: OutputFormat = OutputFormat.TABLE
     page_size: int = 50
     timeout: float = 30.0
-    schema_refresh: SchemaRefresh = SchemaRefresh.ON_HASH_CHANGE
+    schema_refresh: SchemaRefresh = SchemaRefresh.DAILY
 
 
 class Profile(_Frozen):

--- a/nsc/schema/source.py
+++ b/nsc/schema/source.py
@@ -1,16 +1,22 @@
-"""Schema-source resolution chain (Phase 2).
+"""Schema-source resolution chain.
 
-Order:
-  1. --schema flag (path or URL)
-  2. profile.schema_url
-  3. {profile.url}/api/schema/?format=json
-  4. cache hit (matched by profile name + schema hash)
-  5. bundled fallback
+Order, given a `schema_refresh` policy and an optional `force_refresh`:
+  1. --schema flag (path or URL) — always wins, never consults TTL.
+  2. TTL fast-path: if `schema_refresh` allows it and a cache entry for
+     this profile is fresher than the policy's TTL, return it directly
+     without any HTTP roundtrip. Skipped when `force_refresh=True`.
+  3. Network fetch from `profile.schema_url` or `{profile.url}/api/schema/`.
+  4. On fetch failure: any cached entry, then bundled fallback.
+
+Issue #34: prior to the TTL fast-path the schema was fetched on every
+invocation (one extra round-trip per command), which is visible in NetBox
+access logs as a `GET /api/schema/` between every PATCH.
 """
 
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 
 import httpx
@@ -18,6 +24,7 @@ import httpx
 from nsc.builder.build import build_command_model
 from nsc.cache.store import CacheStore
 from nsc.cli.runtime import ResolvedProfile
+from nsc.config.models import SchemaRefresh
 from nsc.config.settings import Paths
 from nsc.model.command_model import CommandModel
 from nsc.schema.hashing import canonical_sha256
@@ -25,9 +32,29 @@ from nsc.schema.loader import LoadedSchema, load_schema
 from nsc.schema.models import OpenAPIDocument
 from nsc.schemas import bundled as _bundled_pkg
 
+_DAILY_SECONDS = 86_400.0
+_WEEKLY_SECONDS = 604_800.0
+
 
 class SchemaSourceError(Exception):
     """Raised when no schema source could be resolved."""
+
+
+def _ttl_for_policy(policy: SchemaRefresh) -> float:
+    """How long a cache entry stays trusted under each refresh policy.
+
+    `0` means "never trust the cache without re-fetching" (the legacy
+    `on-hash-change` behaviour). `inf` means "trust the cache forever"
+    (manual — the user is responsible for refreshing)."""
+    match policy:
+        case SchemaRefresh.MANUAL:
+            return float("inf")
+        case SchemaRefresh.DAILY:
+            return _DAILY_SECONDS
+        case SchemaRefresh.WEEKLY:
+            return _WEEKLY_SECONDS
+        case SchemaRefresh.ON_HASH_CHANGE:
+            return 0.0
 
 
 def resolve_command_model(
@@ -35,12 +62,21 @@ def resolve_command_model(
     paths: Paths,
     profile: ResolvedProfile,
     schema_override: str | None,
+    schema_refresh: SchemaRefresh = SchemaRefresh.ON_HASH_CHANGE,
+    force_refresh: bool = False,
 ) -> CommandModel:
     if schema_override is not None:
         loaded = load_schema(
             schema_override, verify_ssl=profile.verify_ssl, timeout=profile.timeout
         )
         return _build_and_cache(loaded, paths, profile)
+
+    if not force_refresh:
+        ttl = _ttl_for_policy(schema_refresh)
+        if ttl > 0:
+            fresh = _find_fresh_cached(paths, profile.name, ttl_seconds=ttl)
+            if fresh is not None:
+                return fresh
 
     schema_url = (
         str(profile.schema_url)
@@ -104,6 +140,42 @@ def _find_any_cached(paths: Paths, profile_name: str) -> CommandModel | None:
         reverse=True,
     )
     for candidate in candidates:
+        try:
+            return CommandModel.model_validate_json(candidate.read_text())
+        except Exception:
+            continue
+    return None
+
+
+def _find_fresh_cached(
+    paths: Paths,
+    profile_name: str,
+    *,
+    ttl_seconds: float,
+    now: float | None = None,
+) -> CommandModel | None:
+    """Return the newest cached `CommandModel` for `profile_name` whose
+    file mtime is within `ttl_seconds` of `now`. Returns `None` when the
+    profile has never been warmed or every cache entry has aged out.
+
+    `ttl_seconds=inf` (manual refresh) accepts any cache file regardless
+    of age."""
+    profile_dir = paths.cache_dir / profile_name
+    if not profile_dir.exists():
+        return None
+    cutoff = (now if now is not None else time.time()) - ttl_seconds
+    candidates = sorted(
+        profile_dir.glob("*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for candidate in candidates:
+        try:
+            mtime = candidate.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if mtime < cutoff:
+            continue
         try:
             return CommandModel.model_validate_json(candidate.read_text())
         except Exception:

--- a/nsc/schema/source.py
+++ b/nsc/schema/source.py
@@ -130,21 +130,29 @@ def _build_and_cache(loaded: LoadedSchema, paths: Paths, profile: ResolvedProfil
     return model
 
 
+def _iter_cache_files(profile_dir: Path) -> list[Path]:
+    """Cache files only — excludes `<hash>.meta.json` sidecars."""
+    return [p for p in profile_dir.glob("*.json") if not p.name.endswith(".meta.json")]
+
+
 def _find_any_cached(paths: Paths, profile_name: str) -> CommandModel | None:
     profile_dir = paths.cache_dir / profile_name
     if not profile_dir.exists():
         return None
+    store = CacheStore(root=paths.cache_dir)
     candidates = sorted(
-        profile_dir.glob("*.json"),
+        _iter_cache_files(profile_dir),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
     for candidate in candidates:
-        try:
-            return CommandModel.model_validate_json(candidate.read_text())
-        except Exception:
-            continue
+        model = store.load(profile_name, candidate.stem)
+        if model is not None:
+            return model
     return None
+
+
+_CLOCK_SKEW_TOLERANCE_SECONDS = 60.0
 
 
 def _find_fresh_cached(
@@ -155,31 +163,39 @@ def _find_fresh_cached(
     now: float | None = None,
 ) -> CommandModel | None:
     """Return the newest cached `CommandModel` for `profile_name` whose
-    file mtime is within `ttl_seconds` of `now`. Returns `None` when the
-    profile has never been warmed or every cache entry has aged out.
+    sidecar `fetched_at` falls within `ttl_seconds` of `now`. Returns
+    `None` when the profile has never been warmed, the sidecar is missing
+    (so we can't trust the file's age), or every cache entry has aged out.
 
-    `ttl_seconds=inf` (manual refresh) accepts any cache file regardless
-    of age."""
+    Freshness is keyed off the sidecar — never the cache file's mtime —
+    so a `touch`, backup-restore, or `cp -p` cannot fake freshness. A
+    sidecar dated more than `_CLOCK_SKEW_TOLERANCE_SECONDS` in the future
+    is also rejected (likely a clock that jumped forward then back).
+
+    `ttl_seconds=inf` (manual refresh) accepts any sidecar-validated
+    cache file regardless of age. The cache load itself routes through
+    `CacheStore.load` which re-verifies that `<hash>.json`'s contents
+    match `<hash>` — so a tampered or copied JSON file is rejected."""
     profile_dir = paths.cache_dir / profile_name
     if not profile_dir.exists():
         return None
-    cutoff = (now if now is not None else time.time()) - ttl_seconds
-    candidates = sorted(
-        profile_dir.glob("*.json"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    for candidate in candidates:
-        try:
-            mtime = candidate.stat().st_mtime
-        except FileNotFoundError:
+    now_t = now if now is not None else time.time()
+    cutoff = now_t - ttl_seconds
+    skew_limit = now_t + _CLOCK_SKEW_TOLERANCE_SECONDS
+    store = CacheStore(root=paths.cache_dir)
+    fresh: list[tuple[float, str]] = []
+    for candidate in _iter_cache_files(profile_dir):
+        fetched_at = store.load_fetched_at(profile_name, candidate.stem)
+        if fetched_at is None:
             continue
-        if mtime < cutoff:
+        if fetched_at > skew_limit or fetched_at < cutoff:
             continue
-        try:
-            return CommandModel.model_validate_json(candidate.read_text())
-        except Exception:
-            continue
+        fresh.append((fetched_at, candidate.stem))
+    fresh.sort(reverse=True)
+    for _, schema_hash in fresh:
+        model = store.load(profile_name, schema_hash)
+        if model is not None:
+            return model
     return None
 
 

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -89,6 +89,70 @@ the project's `reference/exit-codes.md` page.
 - **Update a field:** `nsc dcim devices update 42 --status decommissioning --apply`
 - **Delete:** `nsc dcim devices delete 42 --apply` (preview first WITHOUT `--apply`)
 
+## Performance: prefer one bulk call to many small ones
+
+Each `nsc` invocation costs at least one HTTP round-trip to NetBox. When
+operating on many objects, **prefer one filtered list call to N individual
+gets, and one NDJSON write to a shell loop of single writes.** A loop of
+1,000 patches is 1,000+ round-trips; a single NDJSON apply is one bulk
+operation.
+
+### Read patterns
+
+- **Need every interface on a device?** Use `list` with a server-side
+  filter, not a loop:
+  ```bash
+  # GOOD — one call, returns all matching rows
+  nsc dcim interfaces list --device 42 --all --output json
+
+  # BAD — N+1 round-trips
+  nsc dcim devices get 42 --output json | jq '.interfaces[]' | \
+    while read id; do nsc dcim interfaces get "$id"; done
+  ```
+- **Need a subset by some non-filterable property?** Pull the wider set
+  once, then `jq` locally:
+  ```bash
+  nsc dcim interfaces list --device 42 --all --output json \
+    | jq '[.[] | select(.enabled == true and (.name | startswith("Gi")))]'
+  ```
+- **Pagination defaults:** `list` returns the first page (50 rows by
+  default). Pass `--all` to follow `next` links until exhausted, or
+  `--limit N` for a hard cap. `nsc describe <tag> <resource>` reveals
+  which fields can be filtered server-side.
+- **Don't query `nsc commands` or `nsc describe` per-resource in a
+  loop.** They serialize the whole command tree; cache the output once
+  per session.
+
+### Write patterns
+
+- **Bulk writes go through `-f <file>.ndjson --apply`.** One JSON object
+  per line; `nsc` streams them through a single bulk endpoint where the
+  schema supports it, otherwise issues one request per line *with shared
+  auth and connection pooling* — still much faster than a shell loop:
+  ```bash
+  # GOOD — one nsc invocation, connection reuse
+  nsc dcim interfaces update -f changes.ndjson --apply
+
+  # BAD — N invocations, N TLS handshakes, N schema-cache lookups
+  while read line; do
+    id=$(echo "$line" | jq .id)
+    nsc dcim interfaces update "$id" -f <(echo "$line") --apply
+  done < changes.ndjson
+  ```
+- **Generate the NDJSON once** with whatever scripting tool you prefer
+  (`jq`, Python, awk). Don't re-run `list` between every patch.
+
+### Schema fetches
+
+`nsc` fetches `/api/schema/` to build its command tree, then caches the
+result under `~/.nsc/cache/<profile>/<schema-hash>.json`. By default the
+cache is trusted for 24h (`schema_refresh: daily` in
+`~/.nsc/config.yaml`), so back-to-back commands don't repeat the schema
+GET. Force a refresh with `--refresh-schema` (one-shot) or set
+`defaults.schema_refresh: on-hash-change` if you need every invocation
+to verify against the live schema. Other policies: `manual` (cache
+indefinitely until manually refreshed), `weekly` (7-day TTL).
+
 ## When something fails
 
 1. Check the exit code (`echo $?`) — the type is in `EXIT_CODES`.
@@ -117,10 +181,14 @@ the project's `reference/exit-codes.md` page.
 ## Cache management
 
 The on-disk cache speeds up repeated invocations against the same NetBox
-schema. It self-heals on schema changes, but you can prune it:
+schema. By default the cache is trusted for 24h before re-fetching the
+live schema (see [Schema fetches](#schema-fetches) above).
 
-- `nsc cache prune` — show what would be deleted.
-- `nsc cache prune --apply` — actually delete orphans.
+- `nsc cache prune` — show what would be deleted (orphan profile dirs
+  and stale-hash files).
+- `nsc cache prune --apply` — actually delete.
+- `nsc --refresh-schema <subcmd>` — force a one-shot live re-fetch
+  bypassing the TTL.
 
 ## NetBox Device Type Library
 

--- a/tests/cache/test_store.py
+++ b/tests/cache/test_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import time
 from pathlib import Path
 
 import pytest
@@ -118,3 +120,40 @@ def test_purge_is_a_noop_when_profile_is_missing(tmp_path: Path) -> None:
     """Removing a profile that never had a cache must not raise."""
     store = CacheStore(root=tmp_path)
     store.purge("never-used")
+
+
+def test_save_writes_fetched_at_sidecar(tmp_path: Path) -> None:
+    """`save` must produce a `<hash>.meta.json` sidecar with a numeric
+    `fetched_at` close to now — the TTL fast-path keys freshness off
+    this, not file mtime."""
+    store = CacheStore(root=tmp_path)
+    before = time.time()
+    store.save("prod", _model("a" * 64))
+    after = time.time()
+
+    sidecar = tmp_path / "prod" / ("a" * 64 + ".meta.json")
+    assert sidecar.exists()
+    fetched_at = json.loads(sidecar.read_text())["fetched_at"]
+    assert before <= fetched_at <= after
+
+
+def test_load_fetched_at_returns_none_when_missing(tmp_path: Path) -> None:
+    """No sidecar means we can't prove freshness — distrust the entry."""
+    store = CacheStore(root=tmp_path)
+    assert store.load_fetched_at("prod", "a" * 64) is None
+
+
+def test_load_fetched_at_round_trips(tmp_path: Path) -> None:
+    store = CacheStore(root=tmp_path)
+    store.save("prod", _model("a" * 64))
+    fetched_at = store.load_fetched_at("prod", "a" * 64)
+    assert fetched_at is not None
+    assert fetched_at > 0
+
+
+def test_load_fetched_at_handles_corrupt_sidecar(tmp_path: Path) -> None:
+    store = CacheStore(root=tmp_path)
+    store.save("prod", _model("a" * 64))
+    sidecar = tmp_path / "prod" / ("a" * 64 + ".meta.json")
+    sidecar.write_text("not json")
+    assert store.load_fetched_at("prod", "a" * 64) is None

--- a/tests/cli/test_app_smoke.py
+++ b/tests/cli/test_app_smoke.py
@@ -70,6 +70,59 @@ def test_offline_with_no_cache_or_bundled_exits_three(
     assert result.exit_code == 3
 
 
+def test_refresh_schema_flag_forces_refetch_through_full_cli(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: `nsc --refresh-schema dcim devices list` must short-
+    circuit the TTL fast-path that a prior call warmed. Exercises the
+    Typer parsing -> _extract_global_overrides -> CLIOverrides ->
+    build_runtime_context -> resolve_command_model wire-through that
+    unit tests for `force_refresh=True` cannot prove."""
+    monkeypatch.setenv("NSC_HOME", str(tmp_path))
+    monkeypatch.setenv("NSC_URL", "https://nb.example/")
+    monkeypatch.setenv("NSC_TOKEN", "tok")
+    for var in ("NSC_PROFILE", "NSC_SCHEMA"):
+        monkeypatch.delenv(var, raising=False)
+
+    schema_doc = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1.0.0"},
+        "tags": [{"name": "dcim"}],
+        "paths": {
+            "/api/dcim/devices/": {
+                "get": {
+                    "operationId": "dcim_devices_list",
+                    "tags": ["dcim"],
+                    "parameters": [],
+                    "responses": {"200": {"description": "ok", "content": {}}},
+                }
+            }
+        },
+        "components": {"schemas": {}},
+    }
+    devices_response = {"count": 0, "next": None, "previous": None, "results": []}
+
+    with respx.mock:
+        schema_route = respx.get("https://nb.example/api/schema/?format=json").mock(
+            return_value=httpx.Response(200, json=schema_doc)
+        )
+        respx.get("https://nb.example/api/dcim/devices/").mock(
+            return_value=httpx.Response(200, json=devices_response)
+        )
+
+        first = CliRunner().invoke(app, ["dcim", "devices", "list"])
+        assert first.exit_code == 0, first.output
+        assert schema_route.call_count == 1
+
+        second = CliRunner().invoke(app, ["dcim", "devices", "list"])
+        assert second.exit_code == 0, second.output
+        assert schema_route.call_count == 1, "DAILY default must hit the fresh-cache fast-path"
+
+        third = CliRunner().invoke(app, ["--refresh-schema", "dcim", "devices", "list"])
+        assert third.exit_code == 0, third.output
+        assert schema_route.call_count == 2, "--refresh-schema must bypass the fast-path"
+
+
 def test_flag_equals_value_form_is_recognized_in_bootstrap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -11,7 +11,7 @@ def test_defaults_have_sensible_values() -> None:
     assert d.output is OutputFormat.TABLE
     assert d.page_size == 50
     assert d.timeout == 30.0
-    assert d.schema_refresh is SchemaRefresh.ON_HASH_CHANGE
+    assert d.schema_refresh is SchemaRefresh.DAILY
 
 
 def test_profile_minimum_fields() -> None:

--- a/tests/schema/test_source_ttl.py
+++ b/tests/schema/test_source_ttl.py
@@ -1,0 +1,262 @@
+"""Tests for schema-source TTL fast-path (issue #34).
+
+Verifies that `resolve_command_model` honours the configured
+`SchemaRefresh` policy and the `force_refresh` flag, skipping the
+`/api/schema/` HTTP roundtrip when a fresh cache entry exists.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from nsc.cli.runtime import ResolvedProfile
+from nsc.config.models import SchemaRefresh
+from nsc.config.settings import Paths
+from nsc.schema.source import resolve_command_model
+
+
+def _profile(**kwargs: Any) -> ResolvedProfile:
+    return ResolvedProfile(
+        name=kwargs.get("name", "prod"),
+        url=kwargs.get("url", "https://nb.example/"),
+        token=kwargs.get("token", "tok"),
+        verify_ssl=kwargs.get("verify_ssl", True),
+        timeout=kwargs.get("timeout", 5.0),
+        schema_url=kwargs.get("schema_url"),
+    )
+
+
+def _paths(tmp_path: Path) -> Paths:
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    return Paths(root=home)
+
+
+def _minimal_schema_doc() -> dict[str, Any]:
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1.0.0"},
+        "tags": [{"name": "dcim"}],
+        "paths": {
+            "/api/dcim/devices/": {
+                "get": {
+                    "operationId": "dcim_devices_list",
+                    "tags": ["dcim"],
+                    "parameters": [],
+                    "responses": {"200": {"description": "ok", "content": {}}},
+                }
+            }
+        },
+        "components": {"schemas": {}},
+    }
+
+
+@respx.mock
+def test_daily_refresh_skips_fetch_when_cache_is_fresh(tmp_path: Path) -> None:
+    """With DAILY policy and a cache entry written seconds ago, the
+    second resolve must NOT hit /api/schema/."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1, "second call must use the fresh cache, not refetch"
+
+
+@respx.mock
+def test_daily_refresh_refetches_when_cache_is_stale(tmp_path: Path) -> None:
+    """When the newest cache entry is older than DAILY's TTL (24h),
+    we must fetch again."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    profile_dir = paths.cache_dir / profile.name
+    aged = os.path.getmtime(next(profile_dir.glob("*.json"))) - 2 * 86400
+    for f in profile_dir.glob("*.json"):
+        os.utime(f, (aged, aged))
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_manual_refresh_uses_cache_indefinitely(tmp_path: Path) -> None:
+    """MANUAL means: never auto-refresh — any cache hit wins,
+    regardless of age."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.MANUAL,
+    )
+    assert route.call_count == 1
+
+    profile_dir = paths.cache_dir / profile.name
+    very_old = 0.0
+    for f in profile_dir.glob("*.json"):
+        os.utime(f, (very_old, very_old))
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.MANUAL,
+    )
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_force_refresh_bypasses_fresh_cache(tmp_path: Path) -> None:
+    """`force_refresh=True` forces a fetch even with a fresh cache."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+        force_refresh=True,
+    )
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_on_hash_change_keeps_legacy_behaviour(tmp_path: Path) -> None:
+    """ON_HASH_CHANGE preserves the v1.0.1 behaviour: every invocation
+    fetches the live schema to compare hashes."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.ON_HASH_CHANGE,
+    )
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.ON_HASH_CHANGE,
+    )
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_no_cache_yet_falls_back_to_fetch(tmp_path: Path) -> None:
+    """First-ever invocation: no cache exists, must fetch even in
+    MANUAL mode (otherwise nothing would work)."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+
+    resolve_command_model(
+        paths=paths,
+        profile=_profile(),
+        schema_override=None,
+        schema_refresh=SchemaRefresh.MANUAL,
+    )
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_explicit_schema_override_ignores_ttl(tmp_path: Path) -> None:
+    """`--schema <path>` always wins; never consults TTL or hits the
+    network."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(500)
+    )
+    schema_path = tmp_path / "s.json"
+    schema_path.write_text(json.dumps(_minimal_schema_doc()), encoding="utf-8")
+    paths = _paths(tmp_path)
+
+    resolve_command_model(
+        paths=paths,
+        profile=_profile(),
+        schema_override=str(schema_path),
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 0
+
+
+def test_default_for_schema_refresh_is_daily() -> None:
+    """The `Defaults.schema_refresh` default must be `daily` —
+    the fast-path is the new normal (issue #34)."""
+    from nsc.config.models import Defaults  # noqa: PLC0415
+
+    assert Defaults().schema_refresh is SchemaRefresh.DAILY
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_ttl"),
+    [
+        (SchemaRefresh.MANUAL, float("inf")),
+        (SchemaRefresh.DAILY, 86400.0),
+        (SchemaRefresh.WEEKLY, 604800.0),
+        (SchemaRefresh.ON_HASH_CHANGE, 0.0),
+    ],
+)
+def test_ttl_for_policy(policy: SchemaRefresh, expected_ttl: float) -> None:
+    from nsc.schema.source import _ttl_for_policy  # noqa: PLC0415
+
+    assert _ttl_for_policy(policy) == expected_ttl

--- a/tests/schema/test_source_ttl.py
+++ b/tests/schema/test_source_ttl.py
@@ -8,7 +8,7 @@ Verifies that `resolve_command_model` honours the configured
 from __future__ import annotations
 
 import json
-import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +20,13 @@ from nsc.cli.runtime import ResolvedProfile
 from nsc.config.models import SchemaRefresh
 from nsc.config.settings import Paths
 from nsc.schema.source import resolve_command_model
+
+
+def _age_sidecars(profile_dir: Path, fetched_at: float) -> None:
+    """Rewrite every `<hash>.meta.json` so the fast path treats the entry
+    as having been fetched at `fetched_at`."""
+    for meta in profile_dir.glob("*.meta.json"):
+        meta.write_text(json.dumps({"fetched_at": fetched_at}))
 
 
 def _profile(**kwargs: Any) -> ResolvedProfile:
@@ -104,9 +111,7 @@ def test_daily_refresh_refetches_when_cache_is_stale(tmp_path: Path) -> None:
     assert route.call_count == 1
 
     profile_dir = paths.cache_dir / profile.name
-    aged = os.path.getmtime(next(profile_dir.glob("*.json"))) - 2 * 86400
-    for f in profile_dir.glob("*.json"):
-        os.utime(f, (aged, aged))
+    _age_sidecars(profile_dir, time.time() - 2 * 86400)
 
     resolve_command_model(
         paths=paths,
@@ -136,9 +141,7 @@ def test_manual_refresh_uses_cache_indefinitely(tmp_path: Path) -> None:
     assert route.call_count == 1
 
     profile_dir = paths.cache_dir / profile.name
-    very_old = 0.0
-    for f in profile_dir.glob("*.json"):
-        os.utime(f, (very_old, very_old))
+    _age_sidecars(profile_dir, 0.0)
 
     resolve_command_model(
         paths=paths,
@@ -260,3 +263,99 @@ def test_ttl_for_policy(policy: SchemaRefresh, expected_ttl: float) -> None:
     from nsc.schema.source import _ttl_for_policy  # noqa: PLC0415
 
     assert _ttl_for_policy(policy) == expected_ttl
+
+
+@respx.mock
+def test_missing_sidecar_forces_refetch_under_daily(tmp_path: Path) -> None:
+    """A cache file without its `<hash>.meta.json` sidecar is distrusted —
+    the fast path can't prove freshness, so we refetch. This is the
+    upgrade path for caches written before the sidecar existed."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    profile_dir = paths.cache_dir / profile.name
+    for meta in profile_dir.glob("*.meta.json"):
+        meta.unlink()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_future_dated_sidecar_is_rejected(tmp_path: Path) -> None:
+    """A `fetched_at` more than a minute in the future (clock skew or
+    tampering) is treated as stale and forces a refetch."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    profile_dir = paths.cache_dir / profile.name
+    _age_sidecars(profile_dir, time.time() + 3600)
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_fast_path_rejects_hash_mismatch(tmp_path: Path) -> None:
+    """If a cache file's contents claim a different schema_hash than its
+    filename, the fast path must reject it (`CacheStore.load` already
+    enforces this — verify the fast path actually routes through it)."""
+    route = respx.get("https://nb.example/api/schema/?format=json").mock(
+        return_value=httpx.Response(200, json=_minimal_schema_doc())
+    )
+    paths = _paths(tmp_path)
+    profile = _profile()
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 1
+
+    profile_dir = paths.cache_dir / profile.name
+    cache_file = next(p for p in profile_dir.glob("*.json") if not p.name.endswith(".meta.json"))
+    payload = json.loads(cache_file.read_text())
+    payload["schema_hash"] = "f" * 64
+    cache_file.write_text(json.dumps(payload))
+
+    resolve_command_model(
+        paths=paths,
+        profile=profile,
+        schema_override=None,
+        schema_refresh=SchemaRefresh.DAILY,
+    )
+    assert route.call_count == 2


### PR DESCRIPTION
## Summary

- Resolves #34. Stops the `GET /api/schema/` between every PATCH that surfaced in the issue logs.
- Wires up the long-dormant `Defaults.schema_refresh` config field as a real TTL fast-path: `daily` (new default, 24h), `weekly` (7d), `manual` (∞), `on-hash-change` (legacy, fetch every call).
- Adds `nsc --refresh-schema <subcmd>` for one-shot forced refresh bypassing the TTL.
- SKILL.md gains a **Performance** section guiding agents to prefer one filtered `list --all` over N `get` calls and one NDJSON `--apply` over shell loops, plus documents the new TTL behaviour.

## Behaviour change

Default policy moves from `on-hash-change` → `daily`. Users with explicit `defaults.schema_refresh` in their config keep their setting. The previous default was the source of the wasted round-trips; the new default matches what `kubectl` does for discovery cache.

## Test plan

- [x] 12 new tests in `tests/schema/test_source_ttl.py` covering: fresh/stale cache under daily, manual ignores age, force_refresh bypass, on-hash-change preserved, no-cache bootstrap, schema-override wins, default constant, and per-policy TTL values.
- [x] Existing `test_cache_hit_skips_rebuild` still asserts legacy fetch-every-time when the policy is `on-hash-change`.
- [x] `just lint` passes (ruff + ruff format + mypy --strict).
- [x] `just test` — 600 passed, 1 skipped.
- [x] `nsc --help` shows the new `--refresh-schema` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)