### PR TITLE
feat(skill): add `nsc skill export <dir>` to copy bundled SKILL.md anywhere

### DIFF
--- a/nsc/cli/skill_commands.py
+++ b/nsc/cli/skill_commands.py
@@ -141,6 +141,30 @@ def _render_json(resolution: _Resolution, mode: str, written: bool, source: Path
     return json.dumps(payload)
 
 
+def _render_export_table(dest_file: Path, source: Path, mode: str, written: bool) -> str:
+    lines: list[str] = []
+    if mode == "dry-run":
+        lines.append("nsc skill export (dry-run) — pass --apply to write")
+        lines.append(f"  would write to {dest_file}")
+        lines.append(f"  source: {source}")
+    elif written:
+        lines.append(f"✓ exported netbox-super-cli skill to {dest_file}")
+    else:
+        lines.append("nsc skill export (no-op)")
+    return "\n".join(lines)
+
+
+def _render_export_json(dest_file: Path, source: Path, mode: str, written: bool) -> str:
+    payload: dict[str, object] = {
+        "mode": mode,
+        "destination": str(dest_file),
+        "source": str(source),
+    }
+    if mode == "apply":
+        payload["written"] = written
+    return json.dumps(payload)
+
+
 def register(app: typer.Typer) -> None:
     skill_app = typer.Typer(
         name="skill",
@@ -182,5 +206,40 @@ def register(app: typer.Typer) -> None:
                 typer.echo(_render_json(resolution, mode, written, source))
             else:
                 typer.echo(_render_table(resolution, mode, written, source))
+
+    @skill_app.command("export")
+    def export_cmd(
+        destination: Annotated[
+            Path,
+            typer.Argument(
+                help=(
+                    "Directory to export the skill into. The skill is written "
+                    "to <destination>/netbox-super-cli/SKILL.md."
+                ),
+            ),
+        ],
+        apply_: Annotated[
+            bool,
+            typer.Option("--apply", help="Actually copy the file (default: dry-run)."),
+        ] = False,
+        output: Annotated[
+            _OutputFormat,
+            typer.Option("--output", "-o", help="table|json"),
+        ] = _OutputFormat.TABLE,
+    ) -> None:
+        dest_file = (destination.expanduser() / BUNDLE_NAME / "SKILL.md").resolve()
+        mode = "apply" if apply_ else "dry-run"
+        written = False
+
+        with bundle_path() as source:
+            if apply_:
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, dest_file)
+                written = True
+
+            if output is _OutputFormat.JSON:
+                typer.echo(_render_export_json(dest_file, source, mode, written))
+            else:
+                typer.echo(_render_export_table(dest_file, source, mode, written))
 
     app.add_typer(skill_app, name="skill")

--- a/tests/cli/test_skill_commands.py
+++ b/tests/cli/test_skill_commands.py
@@ -122,3 +122,86 @@ def test_install_unknown_target_exits_nonzero(home: Path) -> None:
     result = runner.invoke(app, ["skill", "install", "--target", "bogus"])
 
     assert result.exit_code != 0
+
+
+def test_export_dry_run_prints_would_write(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "would write to" in result.output
+    assert "netbox-super-cli/SKILL.md" in result.output
+    assert not (tmp_path / "netbox-super-cli" / "SKILL.md").exists()
+
+
+def test_export_apply_writes_file(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export", str(tmp_path), "--apply"])
+
+    assert result.exit_code == 0, result.output
+    dest = tmp_path / "netbox-super-cli" / "SKILL.md"
+    assert dest.exists()
+    text = dest.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "name: netbox-super-cli" in text
+
+
+def test_export_apply_creates_parent_dirs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    nested = tmp_path / "a" / "b" / "c"
+    result = runner.invoke(app, ["skill", "export", str(nested), "--apply"])
+
+    assert result.exit_code == 0, result.output
+    assert (nested / "netbox-super-cli" / "SKILL.md").exists()
+
+
+def test_export_apply_overwrites_existing_file(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["skill", "export", str(tmp_path), "--apply"])
+    dest = tmp_path / "netbox-super-cli" / "SKILL.md"
+    dest.write_text("stale content")
+
+    result = runner.invoke(app, ["skill", "export", str(tmp_path), "--apply"])
+
+    assert result.exit_code == 0, result.output
+    assert "stale content" not in dest.read_text(encoding="utf-8")
+
+
+def test_export_json_output_dry_run(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export", str(tmp_path), "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "dry-run"
+    assert payload["destination"].endswith("netbox-super-cli/SKILL.md")
+    assert "written" not in payload
+    assert not (tmp_path / "netbox-super-cli" / "SKILL.md").exists()
+
+
+def test_export_json_output_apply(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export", str(tmp_path), "--apply", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "apply"
+    assert payload["written"] is True
+    assert Path(payload["destination"]).exists()
+
+
+def test_export_expands_user_home(home: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export", "~/foo", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    expected = (home / "foo" / "netbox-super-cli" / "SKILL.md").resolve()
+    assert payload["destination"] == str(expected)
+
+
+def test_export_missing_destination_arg_exits_nonzero(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["skill", "export"])
+
+    assert result.exit_code != 0


### PR DESCRIPTION
Closes #30.

## Summary

The existing `nsc skill install --target <agent>` only writes to a few hard-coded per-agent paths (`~/.claude/skills/...`, `~/.agents/skills/...`). When `nsc` is installed via `uv tool install` the bundled `SKILL.md` lives deep under `~/.local/share/uv/tools/...`, which is too long to reference from harnesses whose conventions aren't covered by `install`.

Add `nsc skill export DESTINATION` mirroring `install`'s shape (dry-run by default, `--apply`, `--output table|json`). The skill lands at `<DESTINATION>/netbox-super-cli/SKILL.md`, preserving the conventional `<skills-root>/<skill-name>/SKILL.md` layout that Claude Code/Codex expect — so users can point any harness at the destination they choose.

```
$ nsc skill export ~/my-skills
nsc skill export (dry-run) — pass --apply to write
  would write to /home/user/my-skills/netbox-super-cli/SKILL.md
  source: …/skills/netbox-super-cli/SKILL.md

$ nsc skill export ~/my-skills --apply
✓ exported netbox-super-cli skill to /home/user/my-skills/netbox-super-cli/SKILL.md
```

## Implementation notes

- New command lives next to `install` in `nsc/cli/skill_commands.py`, reusing `BUNDLE_NAME` and `bundle_path()`. No changes to `nsc/skill/` or packaging.
- Two new pure-string renderers (`_render_export_table` / `_render_export_json`) are added next to the install renderers; the install renderers are not touched.
- `~` in the destination is expanded; parent directories are created on `--apply`; existing files are overwritten (consistent with `install`).

## Test plan

- [x] `uv run ruff check nsc tests scripts` — clean
- [x] `uv run ruff format --check nsc tests scripts` — clean
- [x] `uv run mypy --strict nsc scripts` — no issues
- [x] `uv run pytest` — 595 passed, 2 skipped (unchanged from main; 8 new export tests + 13 existing install tests all green)
- [x] Manual smoke: dry-run, `--apply`, `--apply --output json`, deeply-nested destination — all behave as expected; SKILL.md content (`---\nname: netbox-super-cli`) verified at the destination

## New tests

`tests/cli/test_skill_commands.py` — 8 tests covering dry-run output, apply writes the file, parent directory creation, overwrite, JSON dry-run, JSON apply, `~` expansion, and missing-arg exit code.

https://claude.ai/code/session_01ED5YJ1A4pmpViiFhLmH4H3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED5YJ1A4pmpViiFhLmH4H3)_