### PR TITLE
refactor(cache): simplify cache store and schema source

### DIFF
--- a/nsc/cache/store.py
+++ b/nsc/cache/store.py
@@ -142,13 +142,8 @@ class CacheStore:
             shutil.rmtree(target)
 
     def move(self, old: str, new: str) -> None:
-        """Rename a profile's cache directory from `old` to `new`.
-
-        No-op when `old` does not exist (the profile was never warmed). Raises
-        `FileExistsError` when `new` already exists — the caller must purge
-        the target first if that's the intent. Both names are validated to
-        prevent path-component injection (matches `_PROFILE_RE`).
-        """
+        """Raises `FileExistsError` when `new` already exists — caller must purge first.
+        Both names are validated to prevent path-component injection."""
         self._validate_profile(old)
         self._validate_profile(new)
         src = self.root / old
@@ -168,13 +163,6 @@ class CacheStore:
             shutil.rmtree(target)
 
     def enumerate_caches(self) -> list[CacheEntry]:
-        """Walk the cache root and return one CacheEntry per valid <profile>/<hash>.json file.
-
-        Silently skips:
-          - Entries in `self.root` that aren't directories.
-          - Directories whose names don't match `_PROFILE_RE`.
-          - Files whose stems don't match `_HASH_RE` or whose suffix isn't `.json`.
-        """
         if not self.root.exists():
             return []
         entries: list[CacheEntry] = []
@@ -222,7 +210,6 @@ invocations (no profile in config). The prune logic must never delete it."""
 
 
 def _find_orphan_dirs(entries: list[CacheEntry], profile_names: set[str]) -> list[Path]:
-    """Type A: return one Path per profile directory not in config (adhoc excluded)."""
     orphan_dirs: list[Path] = []
     seen_dirs: set[Path] = set()
     for entry in entries:
@@ -240,7 +227,6 @@ def _find_stale_files(
     config: Config,
     fetch_live_hash: Callable[[Profile], str],
 ) -> list[Path]:
-    """Type B: return files whose hash doesn't match the live hash; skip on fetcher error."""
     stale_files: list[Path] = []
     for name in config.profiles:
         try:
@@ -258,7 +244,6 @@ def _find_aged_files(
     orphan_dirs: list[Path],
     cutoff: float,
 ) -> list[Path]:
-    """Type C: return files older than `cutoff`, excluding those inside orphan dirs."""
     orphan_paths = set(orphan_dirs)
     aged: list[Path] = []
     for entry in entries:
@@ -321,12 +306,7 @@ def compute_prune_plan(
 
 
 def prune_orphans(plan: PrunePlan) -> PruneResult:
-    """Delete every path in the plan; tolerant of paths deleted out-of-band.
-
-    Returns counts + freed bytes for output rendering. Bytes are measured
-    BEFORE deletion using `Path.stat()`; if a file vanished between
-    classification and apply, it contributes 0 bytes and 0 deletions.
-    """
+    """Bytes measured before deletion; a file gone between plan and apply contributes 0."""
     deleted_dirs = 0
     deleted_files = 0
     freed = 0

--- a/nsc/schema/source.py
+++ b/nsc/schema/source.py
@@ -138,7 +138,6 @@ def _build_and_cache(loaded: LoadedSchema, paths: Paths, profile: ResolvedProfil
 
 
 def _iter_cache_files(profile_dir: Path) -> list[Path]:
-    """Cache files only — excludes `<hash>.meta.json` sidecars."""
     return [p for p in profile_dir.glob("*.json") if not p.name.endswith(".meta.json")]
 
 
@@ -169,20 +168,12 @@ def _find_fresh_cached(
     ttl_seconds: float,
     now: float | None = None,
 ) -> CommandModel | None:
-    """Return the newest cached `CommandModel` for `profile_name` whose
-    sidecar `fetched_at` falls within `ttl_seconds` of `now`. Returns
-    `None` when the profile has never been warmed, the sidecar is missing
-    (so we can't trust the file's age), or every cache entry has aged out.
-
-    Freshness is keyed off the sidecar — never the cache file's mtime —
+    """Freshness is keyed off the sidecar — never the cache file's mtime —
     so a `touch`, backup-restore, or `cp -p` cannot fake freshness. A
     sidecar dated more than `_CLOCK_SKEW_TOLERANCE_SECONDS` in the future
-    is also rejected (likely a clock that jumped forward then back).
-
-    `ttl_seconds=inf` (manual refresh) accepts any sidecar-validated
-    cache file regardless of age. The cache load itself routes through
-    `CacheStore.load` which re-verifies that `<hash>.json`'s contents
-    match `<hash>` — so a tampered or copied JSON file is rejected."""
+    is rejected (likely a clock that jumped forward then back).
+    `CacheStore.load` re-verifies `<hash>.json` contents match `<hash>`,
+    so a tampered or copied file is rejected."""
     profile_dir = paths.cache_dir / profile_name
     if not profile_dir.exists():
         return None


### PR DESCRIPTION
Closes #52

Code review + simplify pass on nsc/cache/store.py and nsc/schema/source.py.

Changes:
- Removed what-comments from `enumerate_caches`, `_find_orphan_dirs`, `_find_stale_files`, `_find_aged_files`, `_iter_cache_files`
- Trimmed `prune_orphans`, `move`, and `_find_fresh_cached` docstrings to keep only non-obvious why-comments
- No type annotation changes needed (types were already tight)
- No dead branches or over-defensive conditionals found

No behaviour changes. All tests pass.