### PR TITLE
refactor(config): simplify config package

### DIFF
--- a/nsc/config/loader.py
+++ b/nsc/config/loader.py
@@ -30,13 +30,11 @@ def _construct_env(_loader: BaseConstructor, node: ScalarNode) -> str | None:
     raw = str(node.value)
     parts = raw.strip().split(maxsplit=1)
     var = parts[0]
-    parts_count = 2
-    default = parts[1] if len(parts) == parts_count else None
+    default = parts[1] if len(parts) > 1 else None
     return os.environ.get(var, default)
 
 
 def _round_trip_yaml() -> YAML:
-    """Build a fresh round-trip YAML parser shared in shape between loader and writer."""
     yaml = YAML(typ="rt")
     yaml.preserve_quotes = True
     yaml.constructor.add_constructor("!env", _construct_env)

--- a/nsc/config/models.py
+++ b/nsc/config/models.py
@@ -1,8 +1,8 @@
 """Pydantic models for ~/.nsc/config.yaml.
 
-Phase 2 is read-only; these models describe the on-disk shape. The runtime view
-(`ResolvedProfile`) lives in `nsc/cli/runtime.py` and is built by overlaying
-flags + env vars on top of a selected `Profile`.
+These models describe the on-disk shape. The runtime view (`ResolvedProfile`)
+lives in `nsc/cli/runtime.py` and is built by overlaying flags + env vars on
+top of a selected `Profile`.
 """
 
 from __future__ import annotations

--- a/nsc/config/settings.py
+++ b/nsc/config/settings.py
@@ -1,8 +1,4 @@
-"""On-disk locations.
-
-Phase 1 only models the paths under `~/.nsc/`. Profiles, tokens, defaults, and
-the YAML config file are added in Phase 4.
-"""
+"""On-disk locations for `~/.nsc/`."""
 
 from __future__ import annotations
 

--- a/nsc/config/writer.py
+++ b/nsc/config/writer.py
@@ -98,7 +98,7 @@ class ConfigWriteError(Exception):
 
 
 def _construct_env_tag(_loader: BaseConstructor, node: ScalarNode) -> TaggedScalar:
-    return TaggedScalar(value=str(node.value), style=None, tag="!env")
+    return TaggedScalar(value=str(node.value), tag="!env")
 
 
 def _writer_yaml() -> YAML:


### PR DESCRIPTION
Closes #55

Code review + simplify pass on nsc/config/ (writer.py, loader.py, models.py, settings.py).

Changes:
- `loader.py`: removed `parts_count = 2` indirection; replaced with `len(parts) > 1` idiom (cleaner, avoids PLR2004 magic-value lint)
- `loader.py`: removed what-comment on `_round_trip_yaml`
- `writer.py`: dropped redundant `style=None` from `TaggedScalar` constructor (it is the default)
- `models.py`: removed stale phase-reference what-comment from module docstring
- `settings.py`: collapsed stale phase-reference docstring to a single accurate line

No behaviour changes. All 628 tests pass.