### PR TITLE
refactor(http): simplify http package

### DIFF
--- a/nsc/http/audit.py
+++ b/nsc/http/audit.py
@@ -1,4 +1,4 @@
-"""Audit log writers (Phase 3a).
+"""Audit log writers.
 
 Two files under `~/.nsc/logs/`:
   - `last-request.json`  — single-exchange ephemeral, overwritten on every call.

--- a/nsc/http/client.py
+++ b/nsc/http/client.py
@@ -1,4 +1,4 @@
-"""Sync httpx-based NetBox client (Phase 3a: reads + retry + audit)."""
+"""Sync httpx-based NetBox client."""
 
 from __future__ import annotations
 
@@ -34,7 +34,7 @@ _HTTP_4XX_MIN = 400
 
 
 class _ProfileLike(Protocol):
-    url: Any
+    url: object
     token: str | None
     verify_ssl: bool
     timeout: float
@@ -200,7 +200,7 @@ class NetBoxClient:
             try:
                 response = self._client.request(method.value, path, params=params, json=json_body)
             except httpx.RequestError as exc:
-                error_class: ErrorClass | None = classify_error(exc)
+                error_class: ErrorClass = classify_error(exc)
                 duration_ms = int((time.monotonic() - started) * 1000)
                 retry = should_retry(
                     policy, attempt=attempt, status_code=None, error_class=error_class
@@ -255,8 +255,6 @@ class NetBoxClient:
         return str(request.url)
 
     def _raise_for_status(self, response: httpx.Response) -> None:
-        if response.is_success:
-            return
         try:
             body = response.text[:_BODY_SNIPPET_BYTES]
         except Exception:  # pragma: no cover
@@ -336,7 +334,6 @@ class NetBoxClient:
             append_audit_jsonl(entry, path=log_dir / "audit.jsonl")
 
     def _event_hooks(self) -> dict[str, list[Any]]:
-        # Phase 2 stderr streaming — keep alongside Phase 3a audit.jsonl writes.
         def on_request(request: httpx.Request) -> None:
             print(f">>> {request.method} {request.url}", file=sys.stderr)
             for k, v in request.headers.items():

--- a/nsc/http/retry.py
+++ b/nsc/http/retry.py
@@ -1,4 +1,4 @@
-"""Per-method retry policy + error classification (Phase 3a).
+"""Per-method retry policy + error classification.
 
 Pure functions only. The retry *loop* lives in `NetBoxClient`; this module
 decides whether to keep going.


### PR DESCRIPTION
Closes #50

Code review + simplify pass on nsc/http/ (client.py, audit.py, retry.py, errors.py).

Changes:
- Removed dead `if response.is_success: return` guard in `_raise_for_status` — caller already branches on `is_success` before calling, making the guard unreachable
- Tightened `url: Any` to `url: object` in `_ProfileLike` Protocol — only `str()` is called on it, `Any` was an unnecessary type escape
- Narrowed `error_class: ErrorClass | None` annotation to `ErrorClass` — `classify_error` always returns a concrete `ErrorClass`, never `None`
- Removed phase-history what-comments from module docstrings (audit.py, retry.py, client.py) and from `_event_hooks`

No behaviour changes. All tests pass (628 passed, 1 skipped).