### PR TITLE
refactor(nsc): simplify top-level package files

### DIFF
--- a/nsc/cli/config_commands.py
+++ b/nsc/cli/config_commands.py
@@ -33,7 +33,7 @@ def _config_path() -> Path:
 
 def _get_at(doc: CommentedMap, dotted: str) -> object:
     cursor: object = doc
-    for key in [p for p in dotted.split(".") if p]:
+    for key in (p for p in dotted.split(".") if p):
         if not isinstance(cursor, CommentedMap) or key not in cursor:
             raise KeyError(dotted)
         cursor = cursor[key]
@@ -61,8 +61,7 @@ def _get_cmd(key: str) -> None:
 
 def _list_cmd() -> None:
     """Print the entire config file."""
-    doc = load_round_trip(_config_path())
-    typer.echo(dump_round_trip(doc), nl=False)
+    typer.echo(dump_round_trip(load_round_trip(_config_path())), nl=False)
 
 
 def _set_cmd(key: str, value: str) -> None:


### PR DESCRIPTION
Closes #56

Simplify pass on `nsc/cli/config_commands.py`. No behaviour changes. All tests pass.

**Changes:**
- `_get_at`: list comprehension `[p for p in ... if p]` → generator expression (no intermediate list needed)
- `_list_cmd`: inline single-use `doc` variable

`nsc/__init__.py`, `nsc/__main__.py`, `nsc/_version.py` — already minimal, no changes needed.
`nsc/cli/cache_commands.py`, `nsc/cli/init_commands.py` — reviewed, no actionable simplifications found.