### PR TITLE
docs: parity audit — sync all docs with v1.0.3 code state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Third patch release. Headline changes: `nsc login --new` now prompts to fetch th
 
 ### Added
 
-- **`nsc login --new` prompts to fetch the live schema** (issue #32, PR #44). After a new profile is created, `nsc login` asks whether to fetch the live OpenAPI spec immediately. Answering yes primes the schema cache so the next command skips the bootstrap fetch entirely.
-- **`nsc skill export <dir>`** (PR #37). Copies the bundled `SKILL.md` to an arbitrary directory so it can be dropped into any agent harness without `nsc` on the `PATH`. Useful in CI or shared-skill repos where the package is not installed globally.
+- **`nsc login --new` prompts to fetch the live schema** (issue #32, PR #44). After a new profile is created, `nsc login` asks `Fetch and cache the live schema now?` (defaults `Y`) and fetches if accepted. A new `nsc login --fetch-schema` flag fetches unconditionally (no prompt) and also applies to the bare/`--profile` verify path. Either way the schema is fetched with a forced refresh, priming the cache so the next command skips the bootstrap fetch entirely. `--rotate` does not prompt for or fetch the schema.
+- **`nsc skill export <dir>`** (PR #37). Copies the bundled `SKILL.md` into `<dir>/netbox-super-cli/SKILL.md` so it can be dropped into any agent harness without `nsc` on the `PATH`. Dry-run by default (prints the would-write path); `--apply` actually copies. `--output json` emits a structured envelope. Useful in CI or shared-skill repos where the package is not installed globally.
 - **Bundled schemas updated** (PR #36). Ships 4.5.10 and 4.6.0; drops the 4.6.0-beta2 snapshot. Offline fallback is now available for both stable release lines.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -144,11 +144,17 @@ JSON output, error envelope, audit log).
 ```sh
 nsc skill install --target claude-code            # dry-run; prints the destination
 nsc skill install --target claude-code --apply    # actually copies
+
+# Or export to an arbitrary directory (e.g. CI or a shared-skill repo).
+nsc skill export ./skills                          # dry-run; prints the would-write path
+nsc skill export ./skills --apply                  # writes ./skills/netbox-super-cli/SKILL.md
 ```
 
-Targets: `claude-code`, `codex`, `gemini`, `copilot`. Where a target has no
-documented programmatic install path, the helper prints actionable manual
-instructions instead of guessing.
+`skill install` targets: `claude-code`, `codex`, `gemini`, `copilot`. Where a
+target has no documented programmatic install path, the helper prints actionable
+manual instructions instead of guessing. `skill export <dir>` always writes to
+`<dir>/netbox-super-cli/SKILL.md` and, like `install`, is dry-run unless you
+pass `--apply`.
 
 ## License
 

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -9,20 +9,45 @@ wheel and are NOT copied into `~/.nsc/`.
 ~/.nsc/
 ├── config.yaml
 ├── cache/
-│   ├── prod/<schema-hash>.json    # generated CommandModel
+│   ├── prod/<schema-hash>.json         # generated CommandModel
+│   ├── prod/<schema-hash>.meta.json    # sidecar: {"fetched_at": <epoch>}
 │   ├── lab/<schema-hash>.json
-│   └── adhoc/<schema-hash>.json   # env-var-only invocations
+│   └── adhoc/<schema-hash>.json        # env-var-only invocations
 └── logs/
-    ├── nsc.log                     # rotated, 7 days
-    ├── last-request.json           # most recent HTTP exchange
-    └── audit.jsonl                 # append-only mutation log
+    ├── last-request.json               # most recent HTTP exchange (overwritten)
+    └── audit.jsonl                     # append-only mutation log
+                                        #   (rotated to audit.jsonl.1 at 10 MB)
 ```
+
+The location root is `~/.nsc/` unless `NSC_HOME` is set, in which case it is
+`$NSC_HOME` (expanded and resolved).
 
 ## Invalidation
 
-The cache is keyed by `sha256` of the canonicalized schema body. When the live
-schema's hash differs from the cached one, `nsc` regenerates and emits a
-one-line "schema changed, regenerating…" notice on stderr.
+The cache is keyed by `sha256` of the canonicalized schema body. There are two
+distinct caches: this **command-model disk cache** (`<hash>.json`), and the
+**schema-source TTL fast-path** that decides whether to re-fetch the live
+schema at all.
+
+Invalidation is **TTL-gated**, not "every invocation". Under the default
+`daily` policy (`Defaults.schema_refresh = SchemaRefresh.DAILY`) `nsc` trusts
+the cached command-model — and skips the schema fetch entirely — as long as the
+profile's newest `<hash>.meta.json` sidecar `fetched_at` is within the policy's
+TTL. Only once the TTL has lapsed (or the policy forces it) does `nsc` re-fetch
+the live schema; a changed schema then produces a new hash and a new
+`<hash>.json`. Freshness is keyed off the sidecar's `fetched_at`, **not** the
+cache file's mtime, so a `touch`, backup-restore, or `cp -p` cannot fake
+freshness. A sidecar dated more than 60s in the future (clock skew or
+tampering) is rejected.
+
+When a live fetch returns a hash that is already cached, the sidecar's
+`fetched_at` is bumped (`CacheStore.touch_fetched_at`) so the TTL fast-path
+trusts the cache on the next invocation — this also self-heals legacy caches
+written before sidecars existed.
+
+Force a re-fetch sooner with the global `--refresh-schema` flag (bypasses the
+TTL fast-path under any policy) or `nsc login --fetch-schema`. The full policy
+table lives in [Schema loading](schema-loading.md#refresh-modes).
 
 ## Cleaning up
 
@@ -36,7 +61,8 @@ one-line "schema changed, regenerating…" notice on stderr.
    files already covered by rule 1).
 
 The `adhoc` cache is **never pruned automatically** — it represents valid
-env-var-only usage.
+env-var-only usage. Applying a prune also removes each deleted file's
+`<hash>.meta.json` sidecar.
 
 ```sh
 nsc cache prune                      # dry-run

--- a/docs/architecture/command-generation.md
+++ b/docs/architecture/command-generation.md
@@ -5,13 +5,13 @@
 ## The shape
 
 ```python
-CommandModel
+CommandModel(info_title, info_version, schema_hash, tags: dict[str, Tag])
 ├── tags: dict[str, Tag]
-│   └── Tag(name, resources: dict[str, Resource])
+│   └── Tag(name, description?, resources: dict[str, Resource])
 │       └── Resource(name, list_op?, get_op?, create_op?, update_op?, replace_op?,
 │                    delete_op?, custom_actions: list[Operation])
-└── Operation(operation_id, http_method, path, parameters, request_body?,
-              response_schema?, summary?)
+└── Operation(operation_id, http_method, path, summary?, description?,
+              parameters, request_body?, default_columns?)
 ```
 
 Pure Pydantic. JSON-serializable. Cached to disk.

--- a/docs/architecture/http-client.md
+++ b/docs/architecture/http-client.md
@@ -4,35 +4,57 @@
 
 ## What it adds
 
-- Token auth: `Authorization: Token <token>` header, set once per Client.
-- Configurable `verify_ssl` and `timeout` (default 30s).
-- Retries on 5xx: 3 attempts with exponential backoff. The retry path
-  preserves the audit log entry — failed retries do not unredact.
+- Token auth: `Authorization: Token <token>` header (plus
+  `Accept: application/json`), set once per Client.
+- Configurable `verify_ssl` and `timeout` (default 30s, from
+  `Defaults.timeout`).
+- Method-aware retries, up to 3 attempts with exponential backoff
+  (`base_delay` 0.5s, ±25% jitter):
+    - **Reads** (GET/HEAD/OPTIONS) retry on 5xx **and** on connect
+      failures.
+    - **Writes** (POST/PATCH/PUT/DELETE) retry **only** on a provable
+      connect failure (request never left the client). They are
+      **never** retried on 5xx, read-timeout, or ambiguous transport
+      errors — a write that may have reached the server is not replayed.
+  Every attempt is recorded as its own audit entry with `attempt_n` and
+  `final_attempt`; redaction is applied on every write, so a failed
+  retry never unredacts.
 - Pagination helper that follows `next` URLs (used by `--all`).
-- Audit log appender at `~/.nsc/logs/audit.jsonl`.
-- A "last request" snapshot at `~/.nsc/logs/last-request.json` (overwritten
-  each call) — handy for `nsc --debug` triage.
+- Audit log appender at `~/.nsc/logs/audit.jsonl` — written for writes
+  always, and for any request when `--debug` is set.
+- A "last request" snapshot at `~/.nsc/logs/last-request.json`
+  (overwritten every call, regardless of `--debug`) — handy for triage.
 
 ## Auth and the bootstrap path
 
-The first request after startup is a schema fetch (unless cached). All
-subsequent requests reuse the same `httpx.Client` with the auth header attached.
-Token rotation via `nsc login --rotate` does NOT invalidate the cached model
-(the hash of the schema is what matters; the token didn't affect that).
+A schema fetch may run before the first command request (only when the
+TTL fast-path misses — see [Caching](caching.md)); it uses its own
+short-lived `httpx.Client` in `nsc/schema/`, not this `NetBoxClient`.
+Command requests then go through a single `NetBoxClient` whose
+`httpx.Client` carries the auth header for the life of the process.
+Token rotation via `nsc login --rotate` does NOT invalidate the cached
+model (the schema hash is what keys the cache; the token never affected
+it).
 
 ## Audit entry shape
 
 Each line of `audit.jsonl` is a JSON object with:
 
-- `timestamp` (UTC ISO8601)
+- `schema_version`, `timestamp` (UTC ISO8601, `…Z`)
 - `operation_id`, `method`, `url`
-- `request.body` (with sensitive fields redacted to `"<redacted>"`)
-- `request.headers` (Authorization stripped before write)
-- `response.status_code`, `response.body` (excerpted on large bodies)
-- `dry_run: true|false`
-- `attempt_n` for retries
+- `request.headers` (sensitive headers, incl. `Authorization`, rewritten
+  to `"<redacted>"` — the key stays, the value is masked)
+- `request.query`, `request.body` (sensitive `sensitive_paths` fields
+  rewritten to `"<redacted>"`); bodies over 256 KB collapse to
+  `{"_truncated": true, "_size_bytes": N}` with `request.body_truncated`
+- `response.status_code`, `response.headers`, `response.body` (same
+  256 KB truncation via `response.body_truncated`); `response` is `null`
+  on a transport failure
+- `duration_ms`, `attempt_n`, `final_attempt`, `error_kind`
+- `dry_run`, `preflight_blocked`, `record_indices`, `applied`, `explain`
 
-The audit file is append-only; failed writes do NOT unredact. See
+The audit file is append-only and rotates to `audit.jsonl.1` at 10 MB;
+failed writes do NOT unredact. See
 [Writes and safety](../guides/writes-and-safety.md) for the full redaction
 contract.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,21 +1,24 @@
 # Architecture overview
 
-`nsc` is composed of five layers. The "brain" — schema parsing and the normalized
-command-model — knows nothing about Typer, Rich, or httpx. The CLI layer
-consumes the brain; a future TUI could too without changing the brain.
+`nsc` is layered around a framework-free "brain". The brain — schema parsing
+and the normalized command-model — knows nothing about Typer, Rich, or httpx.
+The CLI layer consumes the brain; a future TUI could too without changing the
+brain.
 
 ```
 nsc/
-├── schema/    # OpenAPI fetching, hashing, parsing
-├── model/     # Normalized command-model (data only, framework-free)
-├── builder/   # Schema → CommandModel
-├── cli/       # Typer application; walks the model, registers commands
-├── http/      # Thin httpx wrapper: auth, retries, audit
-├── output/    # Formatters (table/json/jsonl/yaml/csv) + error envelope
-├── config/    # Pydantic config models + ruamel.yaml writer
-├── cache/     # On-disk cache for generated CommandModels
-├── auth/      # Login verification helpers
-└── aliases/   # Curated alias resolver (ls/get/rm/search)
+├── schema/          # OpenAPI fetching, hashing, parsing
+├── model/           # Normalized command-model (data only, framework-free)
+├── builder/         # Schema → CommandModel
+├── cli/             # Typer application; walks the model, registers commands
+├── http/            # Thin httpx wrapper: auth, retries, audit
+├── output/          # Formatters (table/json/jsonl/yaml/csv) + error envelope
+├── config/          # Pydantic config models + ruamel.yaml writer
+├── cache/           # On-disk cache for generated CommandModels
+├── auth/            # Login verification helpers (verify probe, token rotate)
+├── aliases/         # Curated alias resolver (ls/get/rm/search)
+├── skill/           # Bundle-path helper for the portable SKILL.md
+└── schemas/bundled/ # Versioned NetBox OpenAPI snapshots (offline fallback)
 ```
 
 ## The hard rule
@@ -26,7 +29,8 @@ If you need to add a dependency to `model/`, you're solving the wrong problem.
 ## Data flow at runtime
 
 1. `nsc` startup → resolve profile (CLI flags > env > config > adhoc).
-2. Resolve schema source (live URL > cache > bundled fallback).
+2. Resolve schema source (`--schema` override > fresh cache within the
+   TTL policy > live fetch > stale cache > bundled fallback).
 3. Hash + parse → build the command-model (or load cached).
 4. Hand model to Typer; register commands dynamically.
 5. Dispatch.

--- a/docs/architecture/schema-loading.md
+++ b/docs/architecture/schema-loading.md
@@ -18,10 +18,13 @@ and an optional `--refresh-schema` override:
    `{profile.url}/api/schema/?format=json`. The fetched body is hashed;
    if a cache file already exists at that hash it's loaded directly,
    otherwise the command-model is rebuilt and saved.
-4. On fetch failure: any cached entry for the profile (warns once on
-   stderr).
-5. Bundled snapshot at `nsc/schemas/bundled/netbox-<closest-version>.json`
-   (shipped in the wheel) — last-resort offline fallback.
+4. On fetch failure: the newest valid cached entry for the profile
+   (warns once on stderr), sorted by mtime.
+5. Bundled snapshot — the **last (newest) entry** in
+   `nsc/schemas/bundled/manifest.yaml` (currently
+   `netbox-4.6.0.json.gz`), shipped in the wheel. This is the
+   last-resort offline fallback; it is *not* version-matched to the
+   unreachable instance.
 
 ## Hashing
 
@@ -49,12 +52,12 @@ that's the upgrade path for caches written before sidecars existed.
 
 ## Offline behavior
 
-- Live schema unreachable + cache present → use cache, warn once on
-  stderr.
-- Live schema unreachable + no cache → fall back to the closest bundled
-  version, warn loudly.
-- All such errors include a remediation hint pointing at
-  `--refresh-schema` for once the instance is reachable again.
+- Live schema unreachable + cache present → use the newest valid cached
+  entry, warn once on stderr.
+- Live schema unreachable + no cache → fall back to the newest bundled
+  snapshot (last manifest entry), warn once on stderr.
+- Neither cache nor bundled snapshot available → `SchemaSourceError`
+  (exit 3).
 
 ## Refresh modes
 

--- a/docs/contributing/adding-bundled-schemas.md
+++ b/docs/contributing/adding-bundled-schemas.md
@@ -9,14 +9,16 @@ the repo and shipped inside the wheel.
 ```
 nsc/schemas/bundled/
 ├── manifest.yaml
-├── netbox-4.6.0.json.gz
-└── netbox-<other-version>.json.gz
+├── netbox-4.5.10.json.gz
+└── netbox-4.6.0.json.gz
 ```
 
-`manifest.yaml`:
+`manifest.yaml` (newest entry last):
 
 ```yaml
 schemas:
+  - version: "4.5.10"
+    file: "netbox-4.5.10.json.gz"
   - version: "4.6.0"
     file: "netbox-4.6.0.json.gz"
 ```
@@ -56,6 +58,9 @@ versions when they're no longer cited by any active deployment.
 
 1. **First-run offline.** A new install with no cache, no network — the user
    gets a usable command tree from the bundled schema.
-2. **CI without a NetBox container.** `nsc commands --schema bundled-default
-   --output json` produces a deterministic command-model for tests that
-   don't need a live NetBox.
+2. **CI without a NetBox container.** Pointing `--schema` at a bundled
+   snapshot path (e.g. `nsc commands --schema
+   nsc/schemas/bundled/netbox-4.6.0.json.gz --output json`) produces a
+   deterministic command-model for tests that don't need a live NetBox.
+   `--schema` accepts an `http(s)://` URL or a local path; `.json.gz`
+   files are gunzipped automatically — there is no `bundled` keyword.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -22,7 +22,7 @@ just lint          # ruff + ruff format --check + mypy --strict
 just fix           # auto-fix ruff issues
 just bench         # cold-start benchmark (target <300ms median)
 just nsc <args>    # run the local CLI (e.g., just nsc dcim devices list)
-just docs          # serve the docs site at http://localhost:8000
+just docs          # serve the docs site at http://127.0.0.1:8000
 just docs-build    # build the site, fail on broken links / missing nav
 ```
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -10,6 +10,12 @@ process assumes. Release prep (CHANGELOG roll + version bumps) happens
 on a `chore/release-X.Y.Z` feature branch, gets PR-merged into `main`,
 and only then is `vX.Y.Z` tagged on the resulting merge commit.
 
+The same `v*` tag push also publishes the documentation site.
+`docs.yml` runs build-only (`mkdocs build --strict`) on docs-touching
+pull requests, but the GitHub Pages **deploy** job only runs on a `v*`
+tag push — the live docs site updates on release, not on merge to
+`main`.
+
 ## Normal release checklist
 
 1. Full unit suite green: `just test`.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -38,6 +38,7 @@ nsc <tag> <resource> <verb> [args] [options]
    │     │               GET /things/{id}/ → get
    │     │               POST /things/     → create
    │     │               PATCH /things/{id}/ → update
+   │     │               PUT /things/{id}/ → replace
    │     │               DELETE /things/{id}/ → delete
    │     └── path segment (e.g., devices, prefixes)
    └── OpenAPI tag (e.g., dcim, ipam)

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -38,7 +38,6 @@ nsc <tag> <resource> <verb> [args] [options]
    │     │               GET /things/{id}/ → get
    │     │               POST /things/     → create
    │     │               PATCH /things/{id}/ → update
-   │     │               PUT /things/{id}/ → replace
    │     │               DELETE /things/{id}/ → delete
    │     └── path segment (e.g., devices, prefixes)
    └── OpenAPI tag (e.g., dcim, ipam)

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -11,18 +11,24 @@ Two paths to your first command:
 nsc init
 ```
 
-The wizard prompts for:
+The wizard prompts, in order, for:
 
-- A **profile name** (e.g., `prod`, `lab`).
+- A **profile name** (default `default`; e.g., `prod`, `lab`).
 - The NetBox URL.
-- A token (stored verbatim in `~/.nsc/config.yaml` by default; can be `!env NAME` indirection — see [Managing profiles](../guides/managing-profiles.md)).
-- Whether to verify SSL.
+- **Verify SSL certificates?** (default yes).
+- **Token storage** — `plaintext` or `env` (default `plaintext`).
+- Then either an **environment variable name** (if you chose `env` storage — written as
+  an `!env NAME` indirection) or the **token** itself (hidden input, stored verbatim in
+  `~/.nsc/config.yaml`). See [Managing profiles](../guides/managing-profiles.md).
 
-It writes `~/.nsc/config.yaml`, fetches the schema once to warm the cache, and
-exits. You can re-run with `nsc login --new --profile <name>` to add more later.
+`nsc init` is offline-safe: it does not contact NetBox. On success it writes
+`~/.nsc/config.yaml` with the profile, prints the path, and suggests
+`nsc login --profile <name>` as the next step. It does **not** fetch the
+schema — run `nsc login` afterwards to verify the token and prime the schema
+cache (see below).
 
-`nsc init` refuses to overwrite an existing config — use `nsc login --new`
-to add more profiles non-interactively.
+`nsc init` refuses to overwrite an existing config — use
+`nsc login --new --profile <name> --url <url>` to add more profiles.
 
 ## Env-var only
 
@@ -45,11 +51,21 @@ nsc login                          # verify the default profile
 nsc login --profile lab            # verify a specific profile
 nsc login --new --profile staging --url https://netbox-staging.example.com
 nsc login --rotate --profile prod  # rotate the token
+nsc login --fetch-schema           # verify, then fetch & cache the live schema
 ```
 
-`nsc login` calls `GET /api/users/tokens/?limit=1` and prints
-`✓ authenticated as <user>, NetBox <version>` on success. On failure it emits
-the standard `auth_error` envelope (exit 8).
+`nsc login` probes `GET /api/status/` and `GET /api/users/tokens/?limit=1`
+(both must succeed) and prints `✓ authenticated as <user>, NetBox <version>`
+on success. On failure it emits the standard auth error envelope
+(`type: auth`, exit 8).
+
+`--new` requires both `--profile` and `--url`, prompts for the token
+(hidden input), verifies it before writing, and persists the profile. After a
+successful `--new` it also asks **"Fetch and cache the live schema now?"**
+(default **yes**) — accepting primes the schema cache so your first real
+command skips the bootstrap fetch. Pass `--fetch-schema` to any `nsc login`
+(or `--new`) to fetch the schema unconditionally without the prompt;
+`--rotate` neither prompts for nor fetches the schema.
 
 ## Your first read
 

--- a/docs/guides/ci-and-automation.md
+++ b/docs/guides/ci-and-automation.md
@@ -89,10 +89,16 @@ just means one extra fetch on the next run — never a wrong command tree.
 
 ```sh
 # Verify connectivity + auth before doing anything mutating.
-nsc login --output json || { echo "auth failed"; exit 1; }
+nsc login || { echo "auth failed"; exit 1; }
 ```
+
+`nsc login` verifies the active profile's token (exit **8** on auth failure,
+**12** on a config/profile problem). It takes no `--output` flag; on failure it
+prints the standard JSON error envelope.
 
 ## Cleaning up the cache
 
-`nsc cache prune` removes orphan profile dirs and stale-hash files (with `--apply`).
-Safe to run unattended; never deletes the `adhoc` cache.
+`nsc cache prune` removes orphan profile dirs and stale-hash files (it is
+dry-run unless you pass `--apply`). Add `--max-age N` to also prune cache
+files older than N days. Safe to run unattended; never deletes the `adhoc`
+cache.

--- a/docs/guides/ci-and-automation.md
+++ b/docs/guides/ci-and-automation.md
@@ -99,6 +99,7 @@ prints the standard JSON error envelope.
 ## Cleaning up the cache
 
 `nsc cache prune` removes orphan profile dirs and stale-hash files (it is
-dry-run unless you pass `--apply`). Add `--max-age N` to also prune cache
-files older than N days. Safe to run unattended; never deletes the `adhoc`
-cache.
+dry-run unless you pass `--apply`). The default prune never touches the
+`adhoc` cache. Add `--max-age N` to also prune cache files older than N days
+by mtime — note that age-based pruning is profile-agnostic and *will* remove
+aged `adhoc` files too. Safe to run unattended (dry-run by default).

--- a/docs/guides/managing-profiles.md
+++ b/docs/guides/managing-profiles.md
@@ -16,8 +16,8 @@ nsc profiles add lab --url https://netbox-lab.local --token "$LAB_TOKEN"
 ```
 
 This is the scriptable equivalent of `nsc login --new --profile lab`. It runs
-the same verification (`GET /api/users/tokens/?limit=1`) before persisting.
-Refuses if `lab` already exists.
+the same verification (`GET /api/status/` plus `GET /api/users/tokens/?limit=1`)
+before persisting. Refuses if `lab` already exists.
 
 ## Add a profile interactively
 
@@ -25,6 +25,31 @@ Refuses if `lab` already exists.
 nsc init                                                              # first time, no config yet
 nsc login --new --profile staging --url https://netbox-staging.local  # subsequent profiles
 ```
+
+`nsc login --new` requires both `--profile` and `--url`, then prompts for the
+token (hidden input) and runs verification before persisting. Add `--store env
+--env-var NAME` to store the token as an `!env NAME` reference instead of
+plaintext. Refuses (exit 12) if the profile already exists.
+
+After a successful `--new`, `nsc` interactively asks **"Fetch and cache the
+live schema now?"** (default **yes**) — accept it to pre-warm the command-model
+cache, or pass `--fetch-schema` to fetch unconditionally without the prompt.
+
+## Verify, rotate, and fetch the schema
+
+```sh
+nsc login                                    # verify the default profile's token
+nsc login --profile lab                      # verify a specific profile
+nsc login --profile lab --fetch-schema       # verify, then refresh the cached schema
+nsc login --rotate --profile lab             # prompt for a new token, verify, then persist
+```
+
+`nsc login` (bare or with `--profile`) verifies the token by probing
+`GET /api/status/` and `GET /api/users/tokens/?limit=1`; it writes no config.
+`--fetch-schema` additionally force-refreshes the cached OpenAPI schema.
+`--rotate` requires `--profile`, prompts for the new token, verifies it
+*before* writing, and does **not** prompt for or fetch the schema. `--new` and
+`--rotate` are mutually exclusive.
 
 ## Rename / set default / remove
 

--- a/docs/guides/output-formats.md
+++ b/docs/guides/output-formats.md
@@ -1,7 +1,10 @@
 # Output formats
 
-`nsc` ships five output formats. Default is **table** on a TTY and **JSON** when
-stdout is piped.
+`nsc` ships five output formats: `table`, `json`, `jsonl`, `yaml`, `csv`.
+Default is **table** on a TTY and **JSON** when stdout is piped — the piped
+default is JSON even if your config sets a different `defaults.output`.
+Selection precedence (highest first): `--output`/`-o` > `NSC_OUTPUT` env var >
+non-TTY → JSON > `defaults.output` in config (default `table`).
 
 ## The five formats
 

--- a/docs/guides/using-with-ai-agents.md
+++ b/docs/guides/using-with-ai-agents.md
@@ -9,7 +9,7 @@ correctly without trial-and-error.
 | Feature | Mechanism |
 |---|---|
 | Predictable command shape | `nsc <tag> <resource> <verb>` — derived from the OpenAPI schema, no hand-curation |
-| Self-describing | `nsc commands --output json` dumps the full command-model (tags → resources → operations) |
+| Self-describing | `nsc commands --schema <path-or-url> --output json` dumps the full command-model (tags → resources → operations) |
 | Stable machine output | `--output json` everywhere; data on stdout, errors as JSON on stderr (or stdout when `--output json`), non-zero exit on failure |
 | Stable error envelope | `{error, type, endpoint, method, status_code, operation_id, details}` — locked schema, see [Exit codes](../reference/exit-codes.md) |
 | Safe by default | Writes preview as dry-runs; `--apply` is the only path to mutation |

--- a/docs/guides/using-with-ai-agents.md
+++ b/docs/guides/using-with-ai-agents.md
@@ -9,7 +9,7 @@ correctly without trial-and-error.
 | Feature | Mechanism |
 |---|---|
 | Predictable command shape | `nsc <tag> <resource> <verb>` — derived from the OpenAPI schema, no hand-curation |
-| Self-describing | `nsc commands --output json` dumps the full command-model; `nsc describe <tag> <resource>` dumps a resource's fields/filters/operations |
+| Self-describing | `nsc commands --output json` dumps the full command-model (tags → resources → operations) |
 | Stable machine output | `--output json` everywhere; data on stdout, errors as JSON on stderr (or stdout when `--output json`), non-zero exit on failure |
 | Stable error envelope | `{error, type, endpoint, method, status_code, operation_id, details}` — locked schema, see [Exit codes](../reference/exit-codes.md) |
 | Safe by default | Writes preview as dry-runs; `--apply` is the only path to mutation |
@@ -18,15 +18,26 @@ correctly without trial-and-error.
 ## Bundled portable Skill
 
 `nsc` ships a portable Skill bundle at `skills/netbox-super-cli/SKILL.md`
-(installed inside the wheel). Install it into your agent harness with:
+(installed inside the wheel). Install it into a known agent harness with:
 
 ```sh
 nsc skill install --target claude-code            # dry-run; prints the destination
 nsc skill install --target claude-code --apply    # actually copies
 ```
 
+Or export the bundled `SKILL.md` to an arbitrary directory:
+
+```sh
+nsc skill export ./my-skills                      # dry-run; prints the would-write path
+nsc skill export ./my-skills --apply              # actually copies
+```
+
+`nsc skill export <dir>` always writes to `<dir>/netbox-super-cli/SKILL.md` —
+the `netbox-super-cli/` subdirectory is inserted for you. Both `skill install`
+and `skill export` are **dry-run unless `--apply`** is passed.
+
 Use `--output json` for programmatic consumers; the dry-run envelope contains
-the resolved `destination` path.
+the resolved destination path.
 
 ### Per-target resolved paths
 
@@ -54,9 +65,9 @@ When briefing an agent to use `nsc`, include:
    read command.
 2. **The output format.** "Use `--output json` for everything. Errors are JSON
    envelopes — read `.type` for the category, the exit code for control flow."
-3. **Discovery commands.** "Run `nsc commands --output json` to see the whole
-   surface. Run `nsc describe <tag> <resource>` for a specific resource's
-   fields." This prevents the agent from guessing endpoints.
+3. **Discovery commands.** "Run `nsc commands --schema <path-or-url> --output
+   json` to see the whole surface (tags → resources → operations)." This
+   prevents the agent from guessing endpoints.
 4. **The audit log.** "If a command fails unexpectedly, check
    `~/.nsc/logs/audit.jsonl` — it has the exact request and response." This
    replaces guesswork with evidence.
@@ -66,6 +77,6 @@ When briefing an agent to use `nsc`, include:
 - **Asking the agent to skip dry-run.** Just don't. The dry-run is the agent's
   one chance to surface an objection.
 - **Hand-curated endpoint lists in the prompt.** They go stale on every NetBox
-  upgrade. Use `nsc commands --output json` instead.
+  upgrade. Use `nsc commands --schema <path-or-url> --output json` instead.
 - **Authenticating per-command.** Configure a profile (or env vars) once at
   session start.

--- a/docs/guides/working-with-plugins.md
+++ b/docs/guides/working-with-plugins.md
@@ -22,25 +22,33 @@ become e.g. `nsc my_plugin widgets calibrate 7 --apply`.
 ## Discovery
 
 ```sh
-nsc commands --output json | jq '.tags | keys'        # every tag in your install
-nsc describe my_plugin widgets                         # fields, filters, operations
-nsc commands --output json | jq '.tags.my_plugin'      # full subtree
+nsc commands --schema <path-or-url> -o json | jq '.tags | keys'      # every tag
+nsc commands --schema <path-or-url> -o json | jq '.tags.my_plugin'   # full subtree
 ```
+
+`nsc commands` requires an explicit `--schema` (a path or URL to the OpenAPI
+document) and emits JSON only. The dumped tree is
+`{info_title, info_version, schema_hash, tags: {<tag>: {resources: ...}}}`.
 
 ## Schema cache and plugin upgrades
 
-The cache is keyed by the schema's SHA-256 hash. When you upgrade a plugin (or
-any NetBox component that changes the schema), the next `nsc` invocation
-notices the hash change and regenerates the command-model in the background. The
-old `<schema_hash>.json` file becomes stale and gets cleaned by
-`nsc cache prune` — see [Caching](../architecture/caching.md) for the details.
+The cache is keyed by the schema's SHA-256 hash, stored at
+`~/.nsc/cache/<profile>/<sha256>.json`. When you upgrade a plugin (or any
+NetBox component that changes the schema), the next *fresh* schema fetch
+produces a new hash and a new cache file. Under the default `daily` refresh
+policy that fetch happens once the cache TTL (1 day) expires; force it sooner
+with the global `--refresh-schema` flag or `nsc login --fetch-schema`. The old
+`<schema_hash>.json` file becomes stale and gets cleaned by `nsc cache prune`
+— see [Caching](../architecture/caching.md) for the details.
 
 ## When a plugin endpoint is missing
 
 If `nsc` doesn't know about an endpoint you can hit with `curl`:
 
-1. Check `nsc commands --output json | jq '.tags' | grep -i <name>` — the schema
-   may use a different tag than you expect.
-2. Run `nsc refresh --profile <name>` to force re-fetch the schema.
+1. Check `nsc commands --schema <path-or-url> -o json | jq '.tags' | grep -i
+   <name>` — the schema may use a different tag than you expect.
+2. Re-run any command with the global `--refresh-schema` flag (or
+   `nsc login --profile <name> --fetch-schema`) to force re-fetch the schema,
+   bypassing the cache TTL.
 3. Confirm the endpoint is in `/api/schema/?format=json` for your install
    (some plugins generate routes lazily and don't register them with drf-spectacular).

--- a/docs/guides/writes-and-safety.md
+++ b/docs/guides/writes-and-safety.md
@@ -20,6 +20,18 @@ nsc dcim devices update 42 --field status=active --explain
 # Annotates the resolved request with operationId, HTTP method, the matched path.
 ```
 
+## Strict deletes
+
+`--strict` makes a delete of an object that does not exist a hard failure:
+
+```sh
+nsc dcim devices delete 999 --apply --strict
+# Missing object → not_found error, exit code 9 (instead of treating it as a no-op).
+```
+
+Without `--strict`, deleting an absent object is tolerated. Use `--strict` in
+idempotency-sensitive automation where "already gone" should still surface.
+
 ## Bulk vs loop
 
 When the input is a list (JSON array or NDJSON file or stdin) and the schema
@@ -90,6 +102,10 @@ On failure with `--output json`:
   "details": { "source": "server", "body_excerpt": "..." }
 }
 ```
+
+A malformed NDJSON/JSON/YAML input is reported as an `input_error` envelope and
+exits **4** (the same code as a request `validation` error). A `--strict`
+delete of a missing object exits **9** (`not_found`).
 
 The full exit-code table lives at [Exit codes](../reference/exit-codes.md).
 Type values and exit codes are locked — they never change once shipped.

--- a/docs/guides/writes-and-safety.md
+++ b/docs/guides/writes-and-safety.md
@@ -103,8 +103,10 @@ On failure with `--output json`:
 }
 ```
 
-A malformed NDJSON/JSON/YAML input is reported as an `input_error` envelope and
-exits **4** (the same code as a request `validation` error). A `--strict`
+A malformed line in an NDJSON/JSONL bulk input is reported as an `input_error`
+envelope and exits **4** (the same code as a request `validation` error). Any
+other bad input — a malformed single JSON/YAML document, an empty list, a
+missing `-f` file — is a `client` error and exits **6**. A `--strict`
 delete of a missing object exits **9** (`not_found`).
 
 The full exit-code table lives at [Exit codes](../reference/exit-codes.md).

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -60,8 +60,10 @@ nsc dcim devices create -f device.yaml --apply  # actually creates
 Bulk writes use `-f <file>` with a `.ndjson` / `.jsonl` extension (one JSON
 object per line) and the same `--apply` rule applies. Read commands (`list`,
 `get`) ignore `--apply` — never paste it into a read by reflex. A `--strict`
-delete of an object that does not exist exits **9**; an NDJSON/input parse
-error exits **4**.
+delete of an object that does not exist exits **9**. A malformed line in an
+NDJSON/JSONL bulk input exits **4** (`input_error`); any other bad input — a
+malformed single JSON/YAML document, an empty list, a missing `-f` file —
+exits **6** (`client`).
 
 ## Stable JSON output
 
@@ -91,11 +93,14 @@ Errors come back as JSON envelopes (on stderr by default; on stdout when
 ```
 
 Exit codes correspond to envelope `type` (the stable scripting contract):
-`0` success; `1` internal; `2` usage/bootstrap; `3` schema; `4` validation
-*or* input/NDJSON parse error; `5` server (5xx); `6` client; `7` transport;
-`8` auth (401/403); `9` not_found (404, also `--strict` delete of an absent
-object); `10` conflict (409); `11` rate_limited (429); `12` config/profile;
-`13` ambiguous_alias; `14` unknown_alias.
+`0` success; `1` internal; `3` schema; `4` `validation` *or* `input_error`
+(a malformed NDJSON/JSONL line); `5` server (5xx); `6` client (incl. a
+malformed single JSON/YAML input, an empty list, a missing `-f` file);
+`7` transport; `8` auth (401/403); `9` not_found (404, also `--strict`
+delete of an absent object); `10` conflict (409); `11` rate_limited (429);
+`12` config/profile; `13` ambiguous_alias; `14` unknown_alias. (Code `2` is
+an argument/usage error from the CLI framework and is not part of the typed
+contract.)
 
 ## Common patterns
 

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -26,17 +26,26 @@ nsc <tag> <resource> <verb> [args] [--apply] [--output json]
 
 - `<tag>` — the OpenAPI tag, e.g., `dcim`, `ipam`, `tenancy`, `circuits`, `extras`.
 - `<resource>` — plural form, e.g., `devices`, `prefixes`, `tenants`, `vlans`.
-- `<verb>` — `list`, `get`, `create`, `update`, `delete`. (Bulk variants exist
+- `<verb>` — reads: `list`, `get`. Writes: `create`, `update`, `replace`,
+  `delete`, plus any custom actions the schema exposes. `replace` is a
+  PUT-with-id (full-object) replace; `update` is a PATCH. (Bulk variants exist
   for write verbs via `-f <file>` — use a `.ndjson` / `.jsonl` extension to trigger
   NDJSON mode.)
 
-A few curated aliases skip the tag:
+A few curated aliases skip the tag (`ls`, `get`, `rm`, `search`):
 
 - `nsc ls <resource>` — alias for `nsc <tag> <resource> list`.
+- `nsc get <resource> <id_or_name>` — fetch one (dereferences a non-numeric
+  name via `name=`).
+- `nsc rm <resource> <id_or_name>` — delete one (dry-run unless `--apply`).
+- `nsc search <query>` — `/api/search/?q=<query>`.
+
+Plus interactive meta-commands (not aliases):
+
 - `nsc init` — interactive config bootstrap.
-- `nsc login` — interactive token capture.
-- `nsc commands` — dump the entire generated command tree (useful for discovery).
-- `nsc describe <tag> <resource>` — dump one resource's fields, filters, operations.
+- `nsc login` — verify / create / rotate a profile's token.
+- `nsc commands --schema <path-or-url>` — dump the entire generated command
+  tree as JSON (useful for discovery; `--schema` is required here).
 
 ## Dry-run / apply discipline
 
@@ -50,11 +59,17 @@ nsc dcim devices create -f device.yaml --apply  # actually creates
 
 Bulk writes use `-f <file>` with a `.ndjson` / `.jsonl` extension (one JSON
 object per line) and the same `--apply` rule applies. Read commands (`list`,
-`get`, `describe`) ignore `--apply` — never paste it into a read by reflex.
+`get`) ignore `--apply` — never paste it into a read by reflex. A `--strict`
+delete of an object that does not exist exits **9**; an NDJSON/input parse
+error exits **4**.
 
 ## Stable JSON output
 
-Use `--output json` for everything an agent reads:
+The default output is `table`, but when stdout is not a TTY (piped, captured)
+`nsc` auto-switches to `json` — overriding any configured default. Still,
+pass `--output json` (or `-o json`) explicitly for everything an agent reads;
+formats are exactly `table, json, jsonl, yaml, csv`. The `NSC_OUTPUT` env var
+sets the default format (a `--output/-o` flag still wins over it).
 
 ```
 nsc ls devices --output json | jq '.[] | select(.status.value == "active")'
@@ -75,13 +90,16 @@ Errors come back as JSON envelopes (on stderr by default; on stdout when
 }
 ```
 
-Exit codes correspond to envelope `type` — see `nsc commands --output json` or
-the project's `reference/exit-codes.md` page.
+Exit codes correspond to envelope `type` (the stable scripting contract):
+`0` success; `1` internal; `2` usage/bootstrap; `3` schema; `4` validation
+*or* input/NDJSON parse error; `5` server (5xx); `6` client; `7` transport;
+`8` auth (401/403); `9` not_found (404, also `--strict` delete of an absent
+object); `10` conflict (409); `11` rate_limited (429); `12` config/profile;
+`13` ambiguous_alias; `14` unknown_alias.
 
 ## Common patterns
 
-- **Discover the surface:** `nsc commands --output json | jq 'keys'`
-- **Discover a resource:** `nsc describe dcim devices --output json`
+- **Discover the surface:** `nsc commands --schema <path-or-url> --output json | jq 'keys'`
 - **List with filters:** `nsc dcim devices list --site mysite --status active --output json`
 - **Get one:** `nsc dcim devices get 42 --output json`
 - **Create from a YAML file:** `nsc dcim devices create -f new-device.yaml --apply`
@@ -140,11 +158,11 @@ operation.
   device-type), fetch once, partition locally.
 - **Pagination defaults:** `list` returns the first page (50 rows by
   default). Pass `--all` to follow `next` links until exhausted, or
-  `--limit N` for a hard cap. `nsc describe <tag> <resource>` reveals
-  which fields can be filtered server-side.
-- **Don't query `nsc commands` or `nsc describe` per-resource in a
-  loop.** They serialize the whole command tree; cache the output once
-  per session.
+  `--limit N` for a hard cap. `nsc commands --schema <path-or-url>
+  --output json` reveals every resource's parameters (which fields can
+  be filtered server-side).
+- **Don't run `nsc commands` per-resource in a loop.** It serializes
+  the whole command tree; cache the output once per session.
 
 ### Write patterns
 
@@ -188,7 +206,8 @@ indefinitely until manually refreshed), `weekly` (7-day TTL).
 - DO NOT skip `--apply`'s dry-run by reflex. The dry-run is your one chance to
   surface an objection BEFORE the wire request.
 - DO NOT hand-curate endpoint lists in your reasoning. Use
-  `nsc commands --output json` instead — endpoints change with NetBox versions.
+  `nsc commands --schema <path-or-url> --output json` instead — endpoints
+  change with NetBox versions.
 - DO NOT authenticate per-command. Configure a profile (`nsc init` then
   `nsc login`) once at session start; `--profile <name>` switches between them.
 - DO NOT assume singular resource names. Plural-only is the v1 stance:
@@ -197,7 +216,11 @@ indefinitely until manually refreshed), `weekly` (7-day TTL).
 ## Profile management
 
 - `nsc init` — first-time setup; writes `~/.nsc/config.yaml`.
-- `nsc login` — interactive token capture for the active profile.
+- `nsc login` — verify the active profile's token. `nsc login --new
+  --profile <name> --url <url>` creates a new profile (then prompts
+  "Fetch and cache the live schema now?", default yes); `--rotate
+  --profile <name>` replaces an existing token. `--fetch-schema` forces
+  a schema fetch without the prompt.
 - `nsc profiles list` — show configured profiles.
 - `nsc --profile prod ls devices` — one-shot profile override.
 
@@ -208,8 +231,9 @@ schema. By default the cache is trusted for 24h before re-fetching the
 live schema (see [Schema fetches](#schema-fetches) above).
 
 - `nsc cache prune` — show what would be deleted (orphan profile dirs
-  and stale-hash files).
-- `nsc cache prune --apply` — actually delete.
+  and stale-hash files). `prune` is the only `nsc cache` subcommand.
+- `nsc cache prune --apply` — actually delete. Add `--max-age N` to
+  also prune cache files older than N days.
 - `nsc --refresh-schema <subcmd>` — force a one-shot live re-fetch
   bypassing the TTL.
 
@@ -309,6 +333,6 @@ preview each step before committing.
 
 ## See also
 
-- `nsc commands --output json` — the full command tree.
+- `nsc commands --schema <path-or-url> --output json` — the full command tree.
 - Project docs site (deployed on every release tag).
 - [NetBox Device Type Library](https://github.com/netbox-community/devicetype-library) — community YAML definitions.


### PR DESCRIPTION
## Documentation parity audit (post-v1.0.2 → v1.0.3 code state)

Executes the approved **documentation-audit design spec** (`docs/superpowers/specs/2026-05-12-documentation-audit-design.md`). Brings all hand-written user-facing and contributor docs into parity with the current code on `main` (`952570f`, version `1.0.3` in `nsc/_version.py`).

### Method

1. **Phase 1 — Ground-truth capture.** Built a definitive, source-cited CLI inventory (meta-commands + flags, `Config`/`Profile`/`Defaults`, `OutputFormat`, `SchemaRefresh`, exit codes, env vars, bundled schemas) directly from `nsc/` source. Surprising facts spot-verified against source.
2. **Phase 2/3 — File-by-file audit + fix**, in 6 batches, every change traced to a specific source fact. Conservative rule: a flagged uncertainty beats a wrong "fix". No restructuring, no style-only churn, auto-generated files untouched.

### Notable corrections (things agents/users would have gotten wrong)

- **`nsc describe` does not exist** — was referenced ~10× across `SKILL.md`, `using-with-ai-agents.md`, `working-with-plugins.md`. Removed/replaced with `nsc commands --schema … --output json`.
- **`nsc commands` requires `--schema`** — examples that omitted it would fail. Fixed everywhere.
- **`replace` (PUT-with-id) verb** — a real registered verb (`build.py:178`, `registration.py:66-68`) that was missing from the verb lists; restored in `concepts.md`/`SKILL.md`, documented in `command-generation.md`.
- **HTTP retry policy (safety-relevant)** — `http-client.md` claimed "retries 5xx, 3 attempts". Writes are **never** retried on 5xx; corrected to the actual method-aware policy.
- **Schema cache invalidation** — docs implied per-invocation hash check + "regenerating…" notice. Corrected to the TTL fast-path: default policy is `daily`, freshness keyed off the `<hash>.meta.json` sidecar `fetched_at`, forced via `--refresh-schema` / `nsc login --fetch-schema`.
- **`nsc init` is offline-safe** — docs claimed it fetches the schema; it does not. Wizard prompt order corrected.
- **`nsc login`** — documented `--fetch-schema` and the post-`--new` "Fetch and cache the live schema now?" auto-prompt (default yes); `--rotate` does not prompt/fetch.
- **`nsc skill export <dir>`** — newly documented in CHANGELOG/README/guides; clarified it writes `<dir>/netbox-super-cli/SKILL.md` and is dry-run unless `--apply`.
- **Bundled schemas** — corrected stale lists to `4.5.10` + `4.6.0` (4.6.0-beta2 dropped); offline fallback is the newest manifest entry, not a version match.
- **`nsc refresh` / `bundled-default` sentinel** — non-existent; removed.
- Misc: env vars are `NSC_*` only (no `NETBOX_*`); `nsc cache` only has `prune`; non-TTY output auto-switches to JSON; exit-code contract restated from source.

The CHANGELOG already carried a dated `## v1.0.3` section (from `aa8fccf chore(release): 1.0.3`); existing entries were refined for accuracy, none duplicated.

### Verification

- `uv run mkdocs build --strict` — **passes** (no broken links / missing nav).
- Full test suite — **628 passed, 1 skipped** (skip = `NSC_BENCH` benchmark gate).
- `scripts/gen_docs.py` re-run — **no drift**; auto-generated `docs/reference/{cli,config,schemas,exit-codes}.md` are current and were left untouched (they are all generated, not just `cli.md`/`schemas.md`).

### ⚠️ Documentation website deploy is NOT triggered by this merge

`.github/workflows/docs.yml` deploys GitHub Pages **only on a `v*` tag push** (`if: github.ref_type == 'tag'`); PR/`docs/**` runs are build-only (`mkdocs build --strict`). **No `v1.0.3` tag exists** (tags stop at `v1.0.2`; `main` is `v1.0.2-18-g…`). So merging this PR makes the docs CI green but does **not** publish the live site. Publishing requires cutting the `v1.0.3` release tag — a full release (also triggers PyPI publish via `release.yml`) — which was deliberately **not** done autonomously. Tag `v1.0.3` when ready to release; the corrected docs will deploy then.

### Scope

Out of scope per spec: `CLAUDE.md`, `AGENTS.md`, auto-generated reference pages, new pages/guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
