### PR TITLE
chore(release): 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
+## v1.0.4 — 2026-05-16
+
+Maintenance release: a codebase-wide internal simplification pass (no behavioural change), a full documentation parity audit, and a dependency bump. There are no CLI, config, or output-contract changes — upgrading from v1.0.3 is transparent.
+
+### Changed
+
+- **Codebase-wide simplification pass** (PRs #61–#71). Every package was audited to remove dead code, tighten types, and drop unreachable branches: schema parsing (#61), cache store & schema source (#62), output (#63), command model / alias resolver / auth verify (#64), config (#65), http (#66), cli (#68), builder (#69), top-level package files (#70), and the cli writes pipeline (#71). These are internal-only changes — the public CLI surface, command tree, error envelope, and exit codes are unchanged and remain covered by the existing test suite.
+- Bumped `urllib3` 2.6.3 → 2.7.0 (PR #46).
+
+### Documentation
+
+- **Full documentation parity audit** (PR #73). Every hand-written user-facing and contributor page, plus the bundled `SKILL.md`, was audited file-by-file against the current code and corrected. Notable fixes: removed references to non-existent `nsc describe` / `nsc refresh` commands; documented the real `replace` (PUT) verb; corrected the HTTP retry policy (writes are never retried on 5xx); corrected the schema-cache invalidation model to the TTL fast-path; documented `nsc skill export`, `nsc login --fetch-schema`, and the post-`login --new` schema-fetch prompt; and corrected exit-code semantics (a malformed single JSON/YAML input is a `client`/exit-6 error — only a bad NDJSON line is `input_error`/exit 4). Auto-generated reference pages were verified current.
+
 ## v1.0.3 — 2026-05-07
 
 Third patch release. Headline changes: `nsc login --new` now prompts to fetch the live schema (issue #32), the schema TTL fast-path self-heals on hash-confirmed fetches (issue #39), and bundled schemas are updated to 4.5.10 and 4.6.0.

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release **v1.0.4** — bundles all unreleased `main` work since the `v1.0.3` tag.

### Contents
- **Codebase-wide simplification pass** (PRs #61–#71) — dead-code removal + type tightening across every package; internal only, no behavioural change.
- **Documentation parity audit** (PR #73, already merged to `main`) — full file-by-file doc/code reconciliation incl. `SKILL.md`, adversarially reviewed.
- **`urllib3` 2.6.3 → 2.7.0** (PR #46).

### Release-mechanics validated locally (mirrors `release.yml`)
- `nsc/_version.py` + `pyproject.toml` + `uv.lock` bumped to `1.0.4` (same 4-file footprint as the v1.0.3 release commit #45).
- `nsc._version.__version__ == 1.0.4` (matches the `v1.0.4` tag the release workflow will require).
- `uv build` produces `netbox_super_cli-1.0.4-py3-none-any.whl` + `.tar.gz`.
- CHANGELOG `## v1.0.4 ` section extracts cleanly via the workflow's `awk` (release notes non-empty).
- `just lint` (ruff + mypy --strict) clean · `mkdocs build --strict` clean · `628 passed, 1 skipped`.

On merge: tag `v1.0.4` on the resulting `main` commit → `release.yml` (PyPI trusted publish + GitHub Release) and `docs.yml` (Pages deploy) fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)