### PR TITLE
chore(release): 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
+## v1.0.5 — 2026-05-21
+
+Adds opt-in semantic terminal coloring (issue #24). No config migration is
+needed — `color_mode` defaults to `auto`, which colors a stream only when it
+is a TTY, so piped and redirected output is byte-for-byte unchanged.
+
+### Added
+
+- **Semantic terminal coloring** (issue #24, PR #72). A new `defaults.color_mode`
+  config field — `auto` (default), `on`, or `off` — controls colored output.
+  Table cells are colored by meaning: status values (`active`/`enabled`/`online`
+  green, `planned`/`staged` yellow, `failed`/`disabled`/`offline` red), booleans,
+  and empty cells. `nsc explain` traces and Rich error panels are colored too.
+  stdout and stderr are gated independently by each stream's own TTY, so
+  `nsc … | jq` and `nsc … 2>err.log` no longer mis-color one stream or leak
+  ANSI into the other. Structured formats (`json`, `jsonl`, `yaml`, `csv`) are
+  never colored. All server- and user-sourced text is escaped before Rich
+  markup parsing, so stray `[`/`]` in API responses cannot garble output.
+
 ## v1.0.4 — 2026-05-16
 
 Maintenance release: a codebase-wide internal simplification pass (no behavioural change), a full documentation parity audit, and a dependency bump. There are no CLI, config, or output-contract changes — upgrading from v1.0.3 is transparent.

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.0.4"
+version = "1.0.5"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release prep for **v1.0.5**.

- Roll `CHANGELOG.md` — new `## v1.0.5 — 2026-05-21` section.
- Bump `pyproject.toml` and `nsc/_version.py` to `1.0.5`.
- Refresh `uv.lock`.

Headline: opt-in semantic terminal coloring (issue #24, PR #72).

Tag `v1.0.5` is pushed on the merge commit once this is merged and CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)