### PR TITLE
fix(output): render nested-object and list columns in table/csv

### DIFF
--- a/docs/guides/output-formats.md
+++ b/docs/guides/output-formats.md
@@ -43,6 +43,20 @@ columns:
 Unknown column names are silently ignored, so the same config remains valid
 across NetBox versions and plugin changes.
 
+### Nested objects and lists in columns
+
+A column may name a nested field directly or drill in with a dotted path:
+
+- A dotted path selects the leaf scalar: `status.value`, `site.name`.
+- A bare nested object (`site`, `role`, `tenant`, `status`) collapses to its
+  `display` label — `role` renders `Router`, not an empty cell. An object with
+  no `display` field falls back to compact JSON.
+- A list of objects renders as its members' labels joined with `, ` (e.g.
+  `tags` → `prod, edge`); an empty list renders blank.
+
+This applies to both `table` and `csv`. The `json`, `jsonl`, and `yaml` formats
+always keep the full nested structure untouched.
+
 ## Compact JSON
 
 ```sh

--- a/nsc/output/flatten.py
+++ b/nsc/output/flatten.py
@@ -7,11 +7,11 @@ from typing import Any
 
 
 def flatten(record: dict[str, Any], *, columns: list[str] | None = None) -> dict[str, Any]:
-    flat: dict[str, Any] = {}
-    _walk(record, "", flat)
     if columns is None:
+        flat: dict[str, Any] = {}
+        _walk(record, "", flat)
         return flat
-    return {col: flat.get(col, "") for col in columns}
+    return {col: _select(record, col) for col in columns}
 
 
 def _walk(value: Any, prefix: str, out: dict[str, Any]) -> None:
@@ -23,3 +23,27 @@ def _walk(value: Any, prefix: str, out: dict[str, Any]) -> None:
         out[prefix] = json.dumps(value)
     else:
         out[prefix] = value
+
+
+def _select(record: dict[str, Any], path: str) -> Any:
+    cur: Any = record
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return ""
+    return _displayify(cur)
+
+
+def _displayify(value: Any) -> Any:
+    if isinstance(value, dict):
+        display = value.get("display")
+        return display if isinstance(display, str) else json.dumps(value, separators=(",", ":"))
+    if isinstance(value, list):
+        return ", ".join(_as_cell(v) for v in value)
+    return value
+
+
+def _as_cell(value: Any) -> str:
+    rendered = _displayify(value)
+    return "" if rendered is None else str(rendered)

--- a/tests/output/test_csv.py
+++ b/tests/output/test_csv.py
@@ -50,3 +50,26 @@ def test_csv_uses_record_keys_when_no_columns_given() -> None:
     render_csv([{"id": 1, "name": "a"}], stream=buf, columns=None)
     rows = list(csv.reader(io.StringIO(buf.getvalue())))
     assert set(rows[0]) == {"id", "name"}
+
+
+def test_csv_nested_object_column_renders_display() -> None:
+    buf = io.StringIO()
+    render_csv(
+        [{"id": 1, "role": {"display": "Router", "name": "Router"}}],
+        stream=buf,
+        columns=["id", "role"],
+    )
+    rows = list(csv.reader(io.StringIO(buf.getvalue())))
+    assert rows[1] == ["1", "Router"]
+
+
+def test_csv_quotes_joined_list_cell_containing_comma() -> None:
+    buf = io.StringIO()
+    render_csv(
+        [{"id": 1, "tags": [{"display": "edge, dc1"}, {"display": "prod"}]}],
+        stream=buf,
+        columns=["id", "tags"],
+    )
+    # The joined cell ("edge, dc1, prod") survives a CSV round-trip as one field.
+    rows = list(csv.reader(io.StringIO(buf.getvalue())))
+    assert rows[1] == ["1", "edge, dc1, prod"]

--- a/tests/output/test_flatten.py
+++ b/tests/output/test_flatten.py
@@ -62,3 +62,27 @@ def test_flatten_pick_empty_list_renders_blank() -> None:
 
 def test_flatten_pick_null_foreign_key_renders_none() -> None:
     assert flatten({"platform": None}, columns=["platform"]) == {"platform": None}
+
+
+def test_flatten_pick_dotted_path_through_null_renders_blank() -> None:
+    assert flatten({"site": None}, columns=["site.name"]) == {"site.name": ""}
+
+
+def test_flatten_pick_dotted_path_landing_on_list_joins() -> None:
+    record = {"config": {"tags": ["a", "b"]}}
+    assert flatten(record, columns=["config.tags"]) == {"config.tags": "a, b"}
+
+
+def test_flatten_pick_list_of_objects_without_display_uses_json() -> None:
+    record = {"items": [{"a": 1}, {"b": 2}]}
+    assert flatten(record, columns=["items"]) == {"items": '{"a":1}, {"b":2}'}
+
+
+def test_flatten_pick_list_with_none_renders_empty_token() -> None:
+    assert flatten({"vals": ["x", None, "y"]}, columns=["vals"]) == {"vals": "x, , y"}
+
+
+def test_flatten_pick_dotted_path_is_traversal_not_literal_key() -> None:
+    # The dotted column resolves by traversing nested dicts, matching the
+    # documented "drills in" semantics — it does not match a literal dotted key.
+    assert flatten({"a": {"b": 5}}, columns=["a.b"]) == {"a.b": 5}

--- a/tests/output/test_flatten.py
+++ b/tests/output/test_flatten.py
@@ -32,3 +32,33 @@ def test_flatten_pick_returns_only_requested_keys() -> None:
 def test_flatten_pick_returns_blank_for_missing_keys() -> None:
     out = flatten({"id": 1}, columns=["id", "name"])
     assert out == {"id": 1, "name": ""}
+
+
+def test_flatten_pick_renders_nested_object_via_display() -> None:
+    record = {"role": {"id": 1, "name": "Router", "display": "Router"}}
+    assert flatten(record, columns=["role"]) == {"role": "Router"}
+
+
+def test_flatten_pick_nested_object_without_display_falls_back_to_json() -> None:
+    assert flatten({"obj": {"a": 1}}, columns=["obj"]) == {"obj": '{"a":1}'}
+
+
+def test_flatten_pick_resolves_dotted_path_into_nested_object() -> None:
+    assert flatten({"role": {"name": "Router"}}, columns=["role.name"]) == {"role.name": "Router"}
+
+
+def test_flatten_pick_joins_list_of_objects_via_display() -> None:
+    record = {"tags": [{"display": "prod"}, {"display": "edge"}]}
+    assert flatten(record, columns=["tags"]) == {"tags": "prod, edge"}
+
+
+def test_flatten_pick_joins_list_of_scalars() -> None:
+    assert flatten({"tags": ["red", "blue"]}, columns=["tags"]) == {"tags": "red, blue"}
+
+
+def test_flatten_pick_empty_list_renders_blank() -> None:
+    assert flatten({"tags": []}, columns=["tags"]) == {"tags": ""}
+
+
+def test_flatten_pick_null_foreign_key_renders_none() -> None:
+    assert flatten({"platform": None}, columns=["platform"]) == {"platform": None}


### PR DESCRIPTION
## Problem

Closes #78. Columns selected with `--columns` (or via `columns:` config) that point to a **nested object** (NetBox brief FK such as `role`, `site`, `tenant`, `device_type`) rendered as an **empty cell** in `table`/`csv`. Columns pointing to a **list of objects** (e.g. `tags`) rendered as a raw JSON blob.

```
nsc dcim devices list --columns name,status.value,role --output table
# before: role column blank for every row
# after:  role -> "Router"
```

The documented example config in `docs/guides/output-formats.md` (`[id, name, status, site, role]`) was itself hitting this — three of those columns were blank.

## Root cause

`nsc/output/flatten.py`: the `--columns` path picked from a leaf-only flat map built by `_walk`, which never stores a value at a dict's own key, so `flat.get("role", "")` always missed. Lists were stored as `json.dumps(...)`.

## Fix

Resolve each requested column path against the original record, then collapse non-scalars:

| input | render |
|---|---|
| nested object | `display` field (compact-JSON fallback for non-NetBox dicts) |
| list of objects/scalars | members joined with `, ` |
| empty list | blank |
| scalar / null / dotted leaf path | unchanged |

Both `table` and `csv` share the flattener, so both are fixed. The no-`--columns` full-dump path is untouched.

## Tests

TDD: 5 new failing tests reproduced each rendering gap, plus 3 regression guards (dotted paths, scalars, nulls). `tests/output/` — 104 passed. `just lint` clean (ruff + mypy --strict).

## Docs

`docs/guides/output-formats.md` gains a "Nested objects and lists in columns" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)