### PR TITLE
fix(deps): declare click and cap typer<0.26 to fix missing-click crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ classifiers = [
     "Topic :: System :: Networking",
 ]
 dependencies = [
-    "typer>=0.12",
+    # typer 0.26 vendored click as typer._click and dropped its public `click`
+    # dependency; nsc imports the standalone `click` directly and subclasses
+    # TyperGroup, so it stays on the <0.26 line (which uses standalone click)
+    # until that interop is migrated. See issue #82.
+    "typer>=0.12,<0.26",
+    "click>=8.1",
     "rich>=13.7",
     "httpx>=0.27",
     "pydantic>=2.7",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,35 @@
+"""Packaging-metadata guards.
+
+Protects against importing a third-party package directly while relying on
+another dependency to supply it transitively. That is exactly how `click`
+broke on fresh installs (issue #81): `nsc` imports `click` directly, but it
+was only ever pulled in via `typer` — and typer 0.26 dropped its transitive
+`click`, so fresh resolutions had no `click` and `import click` crashed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import tomllib
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _declared_dependencies() -> set[str]:
+    data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps: list[str] = data["project"]["dependencies"]
+    return {re.split(r"[<>=!~\[; ]", dep, maxsplit=1)[0].strip().lower() for dep in deps}
+
+
+def _imports_click() -> bool:
+    pattern = re.compile(r"^\s*(?:import click\b|from click\b)", re.MULTILINE)
+    return any(
+        pattern.search(path.read_text(encoding="utf-8"))
+        for path in (_REPO_ROOT / "nsc").rglob("*.py")
+    )
+
+
+def test_directly_imported_click_is_a_declared_dependency() -> None:
+    assert _imports_click(), "expected nsc to import click directly"
+    assert "click" in _declared_dependencies()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,33 +3,69 @@
 Protects against importing a third-party package directly while relying on
 another dependency to supply it transitively. That is exactly how `click`
 broke on fresh installs (issue #81): `nsc` imports `click` directly, but it
-was only ever pulled in via `typer` — and typer 0.26 dropped its transitive
-`click`, so fresh resolutions had no `click` and `import click` crashed.
+was only ever pulled in via `typer` — and typer 0.26 vendored click as
+`typer._click` and dropped its public `click` dependency, so fresh
+resolutions had no `click` and `import click` crashed.
 """
 
 from __future__ import annotations
 
+import ast
 import pathlib
 import re
+import sys
 import tomllib
+from importlib.metadata import packages_distributions
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_NSC = _REPO_ROOT / "nsc"
+
+
+def _canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
 
 
 def _declared_dependencies() -> set[str]:
     data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     deps: list[str] = data["project"]["dependencies"]
-    return {re.split(r"[<>=!~\[; ]", dep, maxsplit=1)[0].strip().lower() for dep in deps}
+    return {_canonical(re.split(r"[<>=!~\[; ]", dep, maxsplit=1)[0]) for dep in deps}
 
 
-def _imports_click() -> bool:
-    pattern = re.compile(r"^\s*(?:import click\b|from click\b)", re.MULTILINE)
-    return any(
-        pattern.search(path.read_text(encoding="utf-8"))
-        for path in (_REPO_ROOT / "nsc").rglob("*.py")
-    )
+def _top_level_imports(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
 
 
-def test_directly_imported_click_is_a_declared_dependency() -> None:
-    assert _imports_click(), "expected nsc to import click directly"
-    assert "click" in _declared_dependencies()
+def _directly_imported_modules() -> set[str]:
+    names: set[str] = set()
+    for path in _NSC.rglob("*.py"):
+        names |= _top_level_imports(ast.parse(path.read_text(encoding="utf-8")))
+    return names
+
+
+def test_click_is_a_declared_dependency() -> None:
+    # The concrete regression guard for issue #81: nsc imports click directly.
+    assert "click" in _directly_imported_modules()
+    assert _canonical("click") in _declared_dependencies()
+
+
+def test_every_direct_third_party_import_is_declared() -> None:
+    # Generalizes the guard: any top-level third-party module imported anywhere
+    # in nsc/ must resolve to a declared dependency — never a transitive freebie.
+    declared = _declared_dependencies()
+    dist_map = packages_distributions()
+    undeclared: dict[str, set[str]] = {}
+    for module in _directly_imported_modules():
+        if module == "nsc" or module in sys.stdlib_module_names:
+            continue
+        dists = dist_map.get(module)
+        if dists is None:
+            continue  # not an installed distribution (e.g. a namespace shim)
+        if not any(_canonical(dist) in declared for dist in dists):
+            undeclared[module] = set(dists)
+    assert not undeclared, f"third-party imports missing from dependencies: {undeclared}"

--- a/uv.lock
+++ b/uv.lock
@@ -649,6 +649,7 @@ name = "netbox-super-cli"
 version = "1.0.6"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "httpx" },
     { name = "platformdirs" },
     { name = "pydantic" },
@@ -676,13 +677,14 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "platformdirs", specifier = ">=4.2" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "rich", specifier = ">=13.7" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "structlog", specifier = ">=24.1" },
-    { name = "typer", specifier = ">=0.12" },
+    { name = "typer", specifier = ">=0.12,<0.26" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Problem

Closes #81. A fresh `uv tool install`/`pip install` crashes on every invocation:

```
File ".../nsc/cli/app.py", line 7, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```

## Root cause

`nsc` imports the standalone `click` **directly** (`app.py:7`, `init_commands.py:15`, `registration.py:10`) but `click` was never declared in `pyproject.toml` — it came in transitively via typer. **typer 0.26 vendored click as `typer._click` and dropped its public `click` dependency**, so end users resolving `typer>=0.12` get typer 0.26.x with no `click`, and our direct import fails. Our `uv.lock` pinned typer 0.25.1 (still has click), which is why dev/CI never saw it.

The direct `import click` has existed since the first CLI commit and shipped in every release; the new typer in the wild exposed a latent packaging bug.

## Fix

- Declare `click>=8.1` explicitly (we import it directly).
- Pin `typer>=0.12,<0.26` — the last line that uses the standalone `click` our `TyperGroup` subclass overrides (`make_context`/`resolve_command`) are typed against. On typer 0.26 those overrides are a Liskov mismatch against the vendored `typer._click.core.Context` (13 `mypy --strict` errors); migrating to vendored click is tracked in #82.

## Verification

- New packaging guard test: asserts a directly-imported third-party package (`click`) is a declared dependency. Failed before the fix, passes after.
- Full suite: 683 passed. `just lint` clean (ruff + mypy --strict).
- **End-to-end**: fresh `uv pip install .` into a clean venv now resolves typer 0.25.1 **with click present**; `nsc --version` and `nsc --help` run. Before the fix the same flow reproduced the `ModuleNotFoundError`.

Not the shebang — the console-script shebang executed python correctly; the failure was purely the missing module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)