### PR TITLE
feat(output): render choice-field columns via label

### DIFF
--- a/docs/guides/output-formats.md
+++ b/docs/guides/output-formats.md
@@ -48,9 +48,12 @@ across NetBox versions and plugin changes.
 A column may name a nested field directly or drill in with a dotted path:
 
 - A dotted path selects the leaf scalar: `status.value`, `site.name`.
-- A bare nested object (`site`, `role`, `tenant`, `status`) collapses to its
-  `display` label — `role` renders `Router`, not an empty cell. An object with
-  no `display` field falls back to compact JSON.
+- A bare nested object collapses to its human label: FK objects (`site`, `role`,
+  `tenant`) use their `display` field — `role` renders `Router`, not an empty
+  cell — and choice fields (`status`, …) use their `label` — `status` renders
+  `Active`. The precedence is `display` → `label` → compact JSON for objects with
+  neither. The machine value of a choice stays reachable via the dotted path
+  (`status.value` → `active`).
 - A list of objects renders as its members' labels joined with `, ` (e.g.
   `tags` → `prod, edge`); an empty list renders blank.
 

--- a/nsc/output/flatten.py
+++ b/nsc/output/flatten.py
@@ -39,9 +39,9 @@ def _displayify(value: Any) -> Any:
     if isinstance(value, dict):
         # FK objects carry `display`; choice fields carry `label` (status, etc.).
         for key in ("display", "label"):
-            label = value.get(key)
-            if isinstance(label, str):
-                return label
+            candidate = value.get(key)
+            if isinstance(candidate, str):
+                return candidate
         return json.dumps(value, separators=(",", ":"))
     if isinstance(value, list):
         return ", ".join(_as_cell(v) for v in value)

--- a/nsc/output/flatten.py
+++ b/nsc/output/flatten.py
@@ -37,8 +37,12 @@ def _select(record: dict[str, Any], path: str) -> Any:
 
 def _displayify(value: Any) -> Any:
     if isinstance(value, dict):
-        display = value.get("display")
-        return display if isinstance(display, str) else json.dumps(value, separators=(",", ":"))
+        # FK objects carry `display`; choice fields carry `label` (status, etc.).
+        for key in ("display", "label"):
+            label = value.get(key)
+            if isinstance(label, str):
+                return label
+        return json.dumps(value, separators=(",", ":"))
     if isinstance(value, list):
         return ", ".join(_as_cell(v) for v in value)
     return value

--- a/tests/output/test_flatten.py
+++ b/tests/output/test_flatten.py
@@ -63,6 +63,15 @@ def test_flatten_pick_joins_list_of_choice_fields_via_label() -> None:
     assert flatten(record, columns=["vals"]) == {"vals": "A, B"}
 
 
+def test_flatten_pick_non_string_label_falls_back_to_json() -> None:
+    assert flatten({"x": {"label": 7}}, columns=["x"]) == {"x": '{"label":7}'}
+
+
+def test_flatten_pick_joins_mixed_display_and_label_list() -> None:
+    record = {"items": [{"display": "D1"}, {"label": "L1"}]}
+    assert flatten(record, columns=["items"]) == {"items": "D1, L1"}
+
+
 def test_flatten_pick_resolves_dotted_path_into_nested_object() -> None:
     assert flatten({"role": {"name": "Router"}}, columns=["role.name"]) == {"role.name": "Router"}
 

--- a/tests/output/test_flatten.py
+++ b/tests/output/test_flatten.py
@@ -43,6 +43,26 @@ def test_flatten_pick_nested_object_without_display_falls_back_to_json() -> None
     assert flatten({"obj": {"a": 1}}, columns=["obj"]) == {"obj": '{"a":1}'}
 
 
+def test_flatten_pick_choice_field_renders_label() -> None:
+    record = {"status": {"value": "active", "label": "Active"}}
+    assert flatten(record, columns=["status"]) == {"status": "Active"}
+
+
+def test_flatten_pick_display_takes_precedence_over_label() -> None:
+    record = {"x": {"display": "Disp", "label": "Lab"}}
+    assert flatten(record, columns=["x"]) == {"x": "Disp"}
+
+
+def test_flatten_pick_choice_field_value_still_available_via_dotted_path() -> None:
+    record = {"status": {"value": "active", "label": "Active"}}
+    assert flatten(record, columns=["status.value"]) == {"status.value": "active"}
+
+
+def test_flatten_pick_joins_list_of_choice_fields_via_label() -> None:
+    record = {"vals": [{"label": "A"}, {"label": "B"}]}
+    assert flatten(record, columns=["vals"]) == {"vals": "A, B"}
+
+
 def test_flatten_pick_resolves_dotted_path_into_nested_object() -> None:
     assert flatten({"role": {"name": "Router"}}, columns=["role.name"]) == {"role.name": "Router"}
 


### PR DESCRIPTION
## Problem

Closes #85. A `--columns` entry for a NetBox **choice field** rendered raw JSON in `table`/`csv`:

```
nsc dcim devices list --columns name,status,role
# status -> {"value":"active","label":"Active"}
# role   -> PDU
```

FK objects (`role`, `site`) carry `display` and collapse to their human label; choice fields have no `display` — only `{value, label}` — so they fell through to the JSON fallback added in #78.

## Change

Extend the nested-object collapse in `nsc/output/flatten.py` (`_displayify`): try `label` after `display`.

**Precedence: `display` → `label` → compact JSON.**

- `status` → `Active` (was raw JSON)
- `role` → `PDU` (unchanged; `display` still wins)
- `status.value` → `active` (machine value still available via dotted path)
- `json`/`jsonl`/`yaml` keep the full structure.

## Verification

- TDD: 2 new failing tests (choice field → label; list of choice fields → joined labels) + regression guards (display precedence, dotted value still works). `tests/output/` 115 passed, lint clean (ruff + mypy --strict).
- Live: `status` column now renders `Active`.

## Docs

`docs/guides/output-formats.md` updated to document the `display → label → JSON` precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)