### PR TITLE
chore(release): 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
+## v1.0.8 — 2026-06-10
+
+Patch release. Table/CSV columns for choice fields now show their human label
+(issue #85).
+
+### Changed
+
+- **Choice-field columns render their `label`** (issue #85). A `--columns` (or
+  `columns:` config) entry pointing to a NetBox choice field — `status` and
+  other `{value, label}` dicts — previously showed raw JSON in `table`/`csv`
+  because choice fields carry no `display`. The nested-object collapse now uses
+  the precedence `display` → `label` → compact JSON, so `status` renders
+  `Active` (FK objects like `role` still use `display`). The machine value stays
+  reachable via the dotted path `status.value` → `active`, and `json`/`jsonl`/
+  `yaml` keep the full structure.
+
 ## v1.0.7 — 2026-06-09
 
 Patch release. Fixes a hard crash on fresh installs caused by an undeclared

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.0.7"
+version = "1.0.8"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release prep for **v1.0.8**.

Rolls `CHANGELOG.md`, bumps `pyproject.toml` / `nsc/_version.py` / `uv.lock` 1.0.7 → 1.0.8.

### Contents

- feat(output): render choice-field columns via label (#86, closes #85)

Patch release — table/csv columns for choice fields (`status`) now show their `label` instead of raw JSON. Full suite green (690 passed), lint clean. Tag `v1.0.8` is pushed on the merge commit per `docs/contributing/release-process.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)