### PR TITLE
feat(deps): support typer 0.26+ vendored click, lift the <0.26 cap (#82)

### DIFF
--- a/nsc/cli/app.py
+++ b/nsc/cli/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-import click
 import typer
 from typer.core import TyperGroup
 from typer.main import get_group, get_group_from_info
@@ -120,15 +119,20 @@ class _BootstrappingGroup(TyperGroup):
 
     Overrides `make_context` (called once per invocation, before `resolve_command`)
     so dynamic Typer commands are visible to Click's command resolver.
+
+    The `ctx`/`parent`/`Command` types are annotated `Any` rather than tied to a
+    specific click: typer >= 0.26 vendors click as `typer._click`, so binding to
+    the standalone `click.Context`/`Command` here is a Liskov mismatch. `Any`
+    decouples the overrides from whichever click backs `TyperGroup`. See #82.
     """
 
     def make_context(
         self,
         info_name: str | None,
         args: list[str],
-        parent: click.Context | None = None,
+        parent: Any = None,
         **extra: Any,
-    ) -> click.Context:
+    ) -> Any:
         _invocation["runtime"] = None
         _invocation["error"] = None
 
@@ -180,9 +184,7 @@ class _BootstrappingGroup(TyperGroup):
 
         return super().make_context(info_name, args, parent, **extra)
 
-    def resolve_command(
-        self, ctx: click.Context, args: list[str]
-    ) -> tuple[str | None, click.Command | None, list[str]]:
+    def resolve_command(self, ctx: Any, args: list[str]) -> tuple[str | None, Any, list[str]]:
         # Surface a bootstrap error when the requested command was not registered
         # (because bootstrap failed). SchemaSourceError exits 3 per spec; all
         # other bootstrap errors are usage errors (exit 2).

--- a/nsc/cli/registration.py
+++ b/nsc/cli/registration.py
@@ -7,7 +7,13 @@ from collections.abc import Callable
 from typing import Any
 
 import typer
-from click import Choice
+
+try:
+    # typer >= 0.26 vendored click; its TyperChoice is the vendored ParamType
+    # that `typer.Option(click_type=...)` expects.
+    from typer._types import TyperChoice as ChoiceType
+except ImportError:  # pragma: no cover - typer < 0.26 uses standalone click
+    from click import Choice as ChoiceType  # type: ignore[assignment]
 
 from nsc.cli.handlers import (
     handle_create,
@@ -243,7 +249,7 @@ def _to_typed_option(p: Parameter) -> inspect.Parameter:
             None,
             flag_name,
             help=p.description or "",
-            click_type=Choice(p.enum, case_sensitive=True),
+            click_type=ChoiceType(p.enum, case_sensitive=True),
         )
         py_type = str | None
     elif p.primitive is PrimitiveType.BOOLEAN:

--- a/nsc/cli/registration.py
+++ b/nsc/cli/registration.py
@@ -8,12 +8,10 @@ from typing import Any
 
 import typer
 
-try:
-    # typer >= 0.26 vendored click; its TyperChoice is the vendored ParamType
-    # that `typer.Option(click_type=...)` expects.
-    from typer._types import TyperChoice as ChoiceType
-except ImportError:  # pragma: no cover - typer < 0.26 uses standalone click
-    from click import Choice as ChoiceType  # type: ignore[assignment]
+# typer >= 0.26 vendored click; TyperChoice is the vendored `ParamType` that
+# `typer.Option(click_type=...)` expects (a standalone `click.Choice` is a
+# different, rejected type on the vendored-click line). See issue #82.
+from typer._types import TyperChoice as ChoiceType
 
 from nsc.cli.handlers import (
     handle_create,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,11 @@ classifiers = [
 ]
 dependencies = [
     # typer 0.26 vendored click as typer._click and dropped its public `click`
-    # dependency; nsc imports the standalone `click` directly and subclasses
-    # TyperGroup, so it stays on the <0.26 line (which uses standalone click)
-    # until that interop is migrated. See issue #82.
-    "typer>=0.12,<0.26",
+    # dependency. nsc's TyperGroup overrides are decoupled from a specific click
+    # (Any-typed) and Choice is imported from whichever click backs typer, so
+    # both the standalone-click line (<0.26) and vendored-click line (>=0.26)
+    # work. See issue #82.
+    "typer>=0.12",
     "click>=8.1",
     "rich>=13.7",
     "httpx>=0.27",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,14 @@ classifiers = [
     "Topic :: System :: Networking",
 ]
 dependencies = [
-    # typer 0.26 vendored click as typer._click and dropped its public `click`
-    # dependency. nsc's TyperGroup overrides are decoupled from a specific click
-    # (Any-typed) and Choice is imported from whichever click backs typer, so
-    # both the standalone-click line (<0.26) and vendored-click line (>=0.26)
-    # work. See issue #82.
-    "typer>=0.12",
+    # typer 0.26 vendored click as typer._click; nsc's TyperGroup overrides are
+    # decoupled from a specific click (Any-typed) and the choice ParamType comes
+    # from typer._types.TyperChoice (the vendored type Option.click_type wants).
+    # Floor is >=0.26 (the vendored-click line this targets); pinned <0.27 because
+    # nsc leans on typer private internals that already reshuffled across the
+    # 0.25->0.26 minor, so each minor is opted into deliberately. See issue #82.
+    "typer>=0.26,<0.27",
+    # init_commands.py still imports the standalone click package directly.
     "click>=8.1",
     "rich>=13.7",
     "httpx>=0.27",

--- a/tests/cli/test_registration.py
+++ b/tests/cli/test_registration.py
@@ -5,10 +5,11 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import typer
+from typer._types import TyperChoice
 from typer.testing import CliRunner
 
 from nsc.builder.build import build_command_model
-from nsc.cli.registration import _custom_action_verb, register_dynamic_commands
+from nsc.cli.registration import ChoiceType, _custom_action_verb, register_dynamic_commands
 from nsc.cli.runtime import ResolvedProfile, RuntimeContext
 from nsc.config.models import Config, OutputFormat
 from nsc.model.command_model import (
@@ -207,6 +208,16 @@ def test_enum_param_becomes_choice() -> None:
     assert bad.exit_code != 0
     good = CliRunner().invoke(app, ["dcim", "devices", "list", "--status", "active"])
     assert good.exit_code == 0
+
+
+def test_choice_type_is_typers_vendored_choice() -> None:
+    """Pin the choice ParamType to typer's vendored TyperChoice (issue #82).
+
+    `typer.Option(click_type=...)` on the vendored-click line rejects a standalone
+    `click.Choice`; if a future typer renames/removes `typer._types.TyperChoice`
+    this fails loudly instead of silently passing the wrong type.
+    """
+    assert ChoiceType is TyperChoice
 
 
 def test_array_param_becomes_repeatable_option() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "structlog", specifier = ">=24.1" },
-    { name = "typer", specifier = ">=0.12,<0.26" },
+    { name = "typer", specifier = ">=0.12" },
 ]
 
 [package.metadata.requires-dev]
@@ -1101,17 +1101,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "structlog", specifier = ">=24.1" },
-    { name = "typer", specifier = ">=0.12" },
+    { name = "typer", specifier = ">=0.26,<0.27" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
typer 0.26 vendored click as `typer._click`, and `TyperGroup` now subclasses `typer._click.core.Command` with annotations referencing the *vendored* click types. nsc's `TyperGroup` overrides were written against the **standalone** `click` package — a Liskov mismatch (13 `mypy --strict` errors) that also mixed two copies of click. The stopgap pin `typer>=0.12,<0.26` (issue #81 / v1.0.7) is lifted.

## Changes

- **`nsc/cli/app.py`** — `_BootstrappingGroup.make_context` / `resolve_command` annotate the `ctx` / `parent` / command params + returns as `Any`, decoupling the overrides from whichever click backs `TyperGroup`. The bodies only call `super()` and use duck-typed attributes, so behavior is unchanged. The now-unused `import click` is removed.
- **`nsc/cli/registration.py`** — the choice `ParamType` for `typer.Option(click_type=...)` is imported from `typer._types.TyperChoice` (the vendored `ParamType` typer 0.26 expects; a standalone `click.Choice` is a different, rejected type on the vendored-click line). `TyperChoice(choices, case_sensitive=...)` mirrors `click.Choice`'s constructor.
- **`pyproject.toml` / `uv.lock`** — pin `typer>=0.26,<0.27`, relock to 0.26.7. The range is a **truthful, bounded** window: nsc requires typer's `suggest_commands` (absent <~0.21) so the old `>=0.12` floor advertised support that crashed at startup; and nsc leans on typer private internals that already reshuffled across 0.25→0.26, so the upper cap means each minor is opted into deliberately. `click>=8.1` stays (still imported directly by `init_commands.py`).

## Adversarial review

A worktree-isolated multi-agent review confirmed 6 findings (no blockers): the original `typer>=0.12` floor was dishonest and the `<0.26` standalone-click fallback was dead/untested. Addressed by tightening to `>=0.26,<0.27`, importing `TyperChoice` directly (dropping the dead try/except + `type: ignore`), and adding `test_choice_type_is_typers_vendored_choice` to pin the resolved type so a future typer rename fails loudly.

## Verification on typer 0.26.7

- `mypy --strict`: clean (was 13 errors).
- Full suite: 705 passed.
- Runtime smoke: dynamic command tree builds (13 tags, `dcim.devices`), choice params render + constrain values, JSON error envelope unchanged.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)