### PR TITLE
docs: correct audit-redaction + schema-fetch docs for v1.1.0

### DIFF
--- a/docs/architecture/http-client.md
+++ b/docs/architecture/http-client.md
@@ -42,19 +42,22 @@ Each line of `audit.jsonl` is a JSON object with:
 
 - `schema_version`, `timestamp` (UTC ISO8601, `…Z`)
 - `operation_id`, `method`, `url`
-- `request.headers` (sensitive headers, incl. `Authorization`, rewritten
-  to `"<redacted>"` — the key stays, the value is masked)
+- `request.headers` (sensitive headers — `Authorization`, `Cookie`,
+  `Set-Cookie`, `X-API-Key`, `Proxy-Authorization` — rewritten to
+  `"<redacted>"`; the key stays, the value is masked)
 - `request.query`, `request.body` (sensitive `sensitive_paths` fields
   rewritten to `"<redacted>"`); bodies over 256 KB collapse to
   `{"_truncated": true, "_size_bytes": N}` with `request.body_truncated`
-- `response.status_code`, `response.headers`, `response.body` (same
+- `response.status_code`, `response.headers` (redacted with the same
+  sensitive-header set as the request side), `response.body` (same
   256 KB truncation via `response.body_truncated`); `response` is `null`
   on a transport failure
 - `duration_ms`, `attempt_n`, `final_attempt`, `error_kind`
 - `dry_run`, `preflight_blocked`, `record_indices`, `applied`, `explain`
 
-The audit file is append-only and rotates to `audit.jsonl.1` at 10 MB;
-failed writes do NOT unredact. See
+The audit file is append-only and rotates to `audit.jsonl.1` at 10 MB; it is
+created owner-only (`0600`) inside a `0700` logs directory, and failed writes do
+NOT unredact. See
 [Writes and safety](../guides/writes-and-safety.md) for the full redaction
 contract.
 

--- a/docs/architecture/schema-loading.md
+++ b/docs/architecture/schema-loading.md
@@ -17,7 +17,11 @@ and an optional `--refresh-schema` override:
 3. Live fetch from the active profile's `schema_url` (explicit) or
    `{profile.url}/api/schema/?format=json`. The fetched body is hashed;
    if a cache file already exists at that hash it's loaded directly,
-   otherwise the command-model is rebuilt and saved.
+   otherwise the command-model is rebuilt and saved. The fetch is bounded:
+   the loader streams raw wire bytes under a 64 MB cap, requests
+   `Accept-Encoding: identity`, and any `.gz`/`Content-Encoding` body is
+   decompressed incrementally to the same cap — so an oversized or
+   decompression-bomb schema is rejected rather than exhausting memory.
 4. On fetch failure: the newest valid cached entry for the profile
    (warns once on stderr), sorted by mtime.
 5. Bundled snapshot — the **last (newest) entry** in

--- a/docs/guides/writes-and-safety.md
+++ b/docs/guides/writes-and-safety.md
@@ -81,12 +81,20 @@ Both top-level and nested fields are redacted; arrays of objects are redacted
 per-element. Failed writes do NOT unredact — the audit record stays
 sanitized regardless of what happened on the wire.
 
+Sensitive **headers** are masked on **both** the request and the response: the
+values of `Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, and
+`Proxy-Authorization` are rewritten to `<redacted>` (the key stays, the value is
+masked), so session cookies and tokens never land in the log in cleartext.
+
+The log file is created owner-only (`0600`) inside a `0700` directory, mirroring
+`config.yaml`, so a co-located user on a shared host cannot read your mutations.
+
 ### What is NOT redacted
 
 - The endpoint URL (no query parameters from the body).
 - Response bodies (NetBox's response is recorded as-is — if it echoes back a
   password, that's NetBox's bug to fix).
-- Headers other than `Authorization` (which never enters the audit file).
+- Non-sensitive headers (anything outside the set above) are recorded verbatim.
 
 ## Error envelope and exit codes
 


### PR DESCRIPTION
Documentation follow-up to the v1.1.0 security hardening (#88) — the prose docs described behavior that changed.

- **`docs/guides/writes-and-safety.md`** — "What is NOT redacted" claimed *headers other than `Authorization`* aren't redacted, which is now **wrong**. Documents that `Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, and `Proxy-Authorization` are masked on **both** request and response, and that the audit log is created owner-only (`0600` in a `0700` dir).
- **`docs/architecture/http-client.md`** — notes `response.headers` are redacted with the same set, and the `0600`/`0700` file mode.
- **`docs/architecture/schema-loading.md`** — documents the new 64 MB bounded fetch/decompress (raw-wire cap, `Accept-Encoding: identity`, incremental gunzip) that rejects oversized/decompression-bomb schemas.

Auto-generated reference pages (`docs/reference/*`) were unaffected and already pass the freshness check. `mkdocs build --strict` is green.

Docs-only — **no version bump**; deploys with the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)