### PR TITLE
fix(tui): FK fields show name + dropdown, not raw id (#97)

### DIFF
--- a/nsc/tui/bulk.py
+++ b/nsc/tui/bulk.py
@@ -28,17 +28,20 @@ def bulk_diff(
     selected: list[dict[str, object]],
     bulk_set: dict[str, object],
     sensitive_paths: tuple[str, ...],
+    new_displays: dict[str, str] | None = None,
 ) -> list[RecordChange]:
     """Compute the per-record patch and diff rows for a uniform bulk ``set``.
 
     Order of ``selected`` is preserved. A field whose new value equals a
     record's current value contributes no patch entry and no row for that
     record, so heterogeneous current values yield different changed subsets.
+    ``new_displays`` maps a field to the human label of its chosen FK value so
+    the diff renders the name rather than the id.
     """
     changes: list[RecordChange] = []
     for record in selected:
         patch = compute_patch(record, bulk_set)
-        rows = diff_rows(record, patch, sensitive_paths)
+        rows = diff_rows(record, patch, sensitive_paths, new_displays)
         changes.append(RecordChange(record_id=record.get("id"), patch=patch, rows=rows))
     return changes
 

--- a/nsc/tui/fk.py
+++ b/nsc/tui/fk.py
@@ -90,6 +90,16 @@ def _resolve_from_url(field_name: str, current_value: Any, model: CommandModel) 
         )
 
     tag, list_op = located
+    # A `picker` target must carry a usable list endpoint — otherwise the screen
+    # renders a chooser button that can't open anything. Resolvable but
+    # list-less resources fall back to raw-ID entry, like an unknown resource.
+    if list_op is None:
+        return FkTarget(
+            kind="raw_id",
+            field_name=field_name,
+            current_id=current_id,
+            hint=(f"'{resource_name}' has no list endpoint; enter the numeric ID."),
+        )
     return FkTarget(
         kind="picker",
         field_name=field_name,

--- a/nsc/tui/fk.py
+++ b/nsc/tui/fk.py
@@ -28,6 +28,17 @@ FkKind = Literal["picker", "raw_id"]
 _MIN_URL_SEGMENTS = 2
 
 
+def is_fk_value(value: Any) -> bool:
+    """True when ``value`` is a NetBox FK nested object (carries ``id``/``url``).
+
+    The writable schema types FK fields as ``oneOf[integer, brief-ref]`` with no
+    top-level ``type``, so the model has no FK signal; the reliable runtime cue
+    is the record's nested object. A bare ``custom_fields`` dict (no id/url) is
+    deliberately excluded.
+    """
+    return isinstance(value, dict) and ("id" in value or "url" in value)
+
+
 class FkTarget(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 

--- a/nsc/tui/forms.py
+++ b/nsc/tui/forms.py
@@ -87,8 +87,18 @@ def compute_patch(original: dict[str, object], staged: dict[str, object]) -> dic
     return patch
 
 
-def _display(value: object) -> str:
+def fk_display(value: object) -> str:
+    """Human-readable label for a value, resolving FK nested objects.
+
+    NetBox FK objects carry ``display`` (and usually ``name``/``slug``); prefer
+    those over the bare ``id`` so the diff shows e.g. ``Top of Rack Switch``
+    rather than ``12``. Non-dict values render via ``str``.
+    """
     if isinstance(value, dict):
+        for key in ("display", "name", "slug"):
+            label = value.get(key)
+            if label:
+                return str(label)
         ident = value.get("id")
         if ident is not None:
             return str(ident)
@@ -99,13 +109,21 @@ def diff_rows(
     original: dict[str, object],
     patch: dict[str, object],
     sensitive_paths: tuple[str, ...],
+    new_displays: dict[str, str] | None = None,
 ) -> list[DiffRow]:
-    """Render ``patch`` as human-readable old -> new rows for the confirm modal."""
+    """Render ``patch`` as human-readable old -> new rows for the confirm modal.
+
+    ``new_displays`` overrides a field's rendered *new* value — used for FK
+    fields whose staged value is a bare id but whose chosen label is known
+    (e.g. picked from the record chooser). The patch still carries the id.
+    """
+    overrides = new_displays or {}
     rows: list[DiffRow] = []
     for name, new_value in patch.items():
         if name in sensitive_paths:
             rows.append(DiffRow(field=name, old_display="****", new_display="****"))
             continue
-        old_display = _display(original[name]) if name in original else ""
-        rows.append(DiffRow(field=name, old_display=old_display, new_display=str(new_value)))
+        old_display = fk_display(original[name]) if name in original else ""
+        new_display = overrides.get(name, str(new_value))
+        rows.append(DiffRow(field=name, old_display=old_display, new_display=new_display))
     return rows

--- a/nsc/tui/screens/bulk_edit_form.py
+++ b/nsc/tui/screens/bulk_edit_form.py
@@ -21,8 +21,13 @@ from textual.widgets import Button, Footer, Header, Input, Label, ProgressBar, S
 from nsc.model.command_model import CommandModel, Operation
 from nsc.tui._bindings import textual_bindings
 from nsc.tui.bulk import RecordChange, shared_values
-from nsc.tui.forms import SET_NULL, WidgetSpec, field_to_widget
+from nsc.tui.fk import is_fk_value, resolve_fk_target
+from nsc.tui.forms import SET_NULL, WidgetSpec, field_to_widget, fk_display
 from nsc.tui.view import detail_path
+
+# Sentinel: a picker FK opted in with neither a pick nor a shared value
+# contributes nothing, so it never nulls the relation.
+_NO_SEED = object()
 
 
 class _Client(Protocol):
@@ -62,6 +67,8 @@ class BulkEditForm(Screen[None]):
         self._specs: dict[str, WidgetSpec] = {}
         self._values: dict[str, Any] = {}
         self._included: set[str] = set()
+        self._fk_kinds: dict[str, str] = {}
+        self._fk_labels: dict[str, str] = {}
         body = update_op.request_body
         field_names = list(body.fields) if body is not None else []
         # Shared current value per field, to seed the widgets (does NOT opt the
@@ -99,7 +106,47 @@ class BulkEditForm(Screen[None]):
             if spec.nullable:
                 yield Button("∅", id=f"setnull-{name}", classes="bulk-setnull")
 
+    def _is_fk(self, name: str, spec: WidgetSpec) -> bool:
+        if spec.kind in ("select", "switch", "masked") or spec.is_float:
+            return False
+        return name.endswith("_id") or any(
+            is_fk_value(record.get(name)) for record in self._selected
+        )
+
+    def _fk_nested_value(self, name: str) -> Any:
+        """A representative nested FK object across the selection, for resolution."""
+        for record in self._selected:
+            value = record.get(name)
+            if is_fk_value(value):
+                return value
+        return None
+
+    def _fk_seed_label(self, name: str) -> str:
+        shared_id = self._shared.get(name)
+        if shared_id is None:
+            return ""
+        for record in self._selected:
+            value = record.get(name)
+            if isinstance(value, dict) and value.get("id") == shared_id:
+                return fk_display(value)
+        return str(shared_id)
+
+    def _compose_fk(self, name: str) -> ComposeResult:
+        target = resolve_fk_target(name, self._fk_nested_value(name), self._model)
+        self._fk_kinds[name] = target.kind
+        shared_id = self._shared.get(name)
+        if target.kind == "raw_id":
+            text = "" if shared_id is None else str(shared_id)
+            yield Input(value=text, id=f"field-{name}")
+            if target.hint:
+                yield Label(target.hint, classes="bulk-fk-hint")
+            return
+        yield Button(f"{name}: {self._fk_seed_label(name)}", id=f"fk-{name}", classes="bulk-fk")
+
     def _compose_widget(self, name: str, spec: WidgetSpec) -> ComposeResult:
+        if self._is_fk(name, spec):
+            yield from self._compose_fk(name)
+            return
         shared = self._shared.get(name)
         if spec.kind == "select":
             options = [(choice, choice) for choice in spec.choices]
@@ -126,12 +173,15 @@ class BulkEditForm(Screen[None]):
 
     def _coerce_input(self, name: str, raw: str) -> Any:
         spec = self._specs.get(name)
-        if spec is None or spec.kind != "number":
+        numeric = (spec is not None and spec.kind == "number") or self._fk_kinds.get(
+            name
+        ) == "raw_id"
+        if not numeric:
             return raw
         if raw == "":
             return None
         try:
-            return float(raw) if spec.is_float else int(raw)
+            return float(raw) if spec is not None and spec.is_float else int(raw)
         except ValueError:
             return raw
 
@@ -140,7 +190,10 @@ class BulkEditForm(Screen[None]):
         if include is not None:
             if event.value:
                 self._included.add(include)
-                self._values.setdefault(include, self._read_widget_value(include))
+                if include not in self._values:
+                    seed = self._read_widget_value(include)
+                    if seed is not _NO_SEED:
+                        self._values[include] = seed
             else:
                 self._included.discard(include)
             return
@@ -150,6 +203,9 @@ class BulkEditForm(Screen[None]):
 
     def _read_widget_value(self, name: str) -> Any:
         spec = self._specs.get(name)
+        if self._fk_kinds.get(name) == "picker":
+            shared_id = self._shared.get(name)
+            return shared_id if shared_id is not None else _NO_SEED
         if spec is not None and spec.kind == "select":
             value = self.query_one(f"#field-{name}", Select).value
             return None if value is Select.NULL else value
@@ -173,6 +229,27 @@ class BulkEditForm(Screen[None]):
         name = self._strip(ident, "setnull-")
         if name is not None:
             self._values[name] = SET_NULL
+            # Drop any picked label so the diff can't show a name while the
+            # patch nulls the relation.
+            self._fk_labels.pop(name, None)
+            return
+        fk = self._strip(ident, "fk-")
+        if fk is not None:
+            self._open_picker(fk)
+
+    def _open_picker(self, name: str) -> None:
+        target = resolve_fk_target(name, self._fk_nested_value(name), self._model)
+        if target.list_op is None:
+            return
+        from nsc.tui.screens.record_picker import RecordPicker  # noqa: PLC0415
+
+        def _stage(result: tuple[int, str] | None) -> None:
+            if result is not None:
+                self._values[name] = result[0]
+                self._fk_labels[name] = result[1]
+                self.query_one(f"#fk-{name}", Button).label = f"{name}: {result[1]}"
+
+        self.app.push_screen(RecordPicker(self._client, target.list_op, target.current_id), _stage)
 
     def action_preview(self) -> None:
         from nsc.tui.bulk import bulk_diff  # noqa: PLC0415
@@ -180,7 +257,7 @@ class BulkEditForm(Screen[None]):
 
         body = self._op.request_body
         sensitive = body.sensitive_paths if body is not None else ()
-        changes = bulk_diff(self._selected, self.bulk_set, sensitive)
+        changes = bulk_diff(self._selected, self.bulk_set, sensitive, self._fk_labels)
 
         def _on_confirm(confirmed: bool | None) -> None:
             if confirmed:

--- a/nsc/tui/screens/detail.py
+++ b/nsc/tui/screens/detail.py
@@ -23,7 +23,7 @@ from nsc.model.command_model import CommandModel, Resource
 from nsc.output.flatten import flatten
 from nsc.tui._bindings import textual_bindings
 from nsc.tui.errors import api_error_message
-from nsc.tui.fk import resolve_fk_target
+from nsc.tui.fk import is_fk_value, resolve_fk_target
 from nsc.tui.forms import SET_NULL, WidgetSpec, compute_patch, diff_rows, field_to_widget
 from nsc.tui.relations import RelatedView, related_views
 from nsc.tui.view import detail_path
@@ -69,6 +69,7 @@ class DetailScreen(Screen[None]):
         self._specs: dict[str, WidgetSpec] = {}
         self._rows: list[_FieldRow] = []
         self.staged: dict[str, Any] = {}
+        self._fk_labels: dict[str, str] = {}
         self._editing: str | None = None
         self._relations: list[RelatedView] = related_views(model, resource_name)
         self.title = f"{resource_name} #{record.get('id', '?')}"
@@ -129,8 +130,11 @@ class DetailScreen(Screen[None]):
             staged = self.staged[row.name]
             if staged is SET_NULL:
                 return "(null)"
-            # Never echo a just-typed secret back into the on-screen table.
-            return "****" if sensitive and staged != "" else str(staged)
+            # Never echo a just-typed secret; a picked FK stages a bare id, so
+            # show its chosen label rather than the number.
+            return (
+                "****" if sensitive and staged != "" else self._fk_labels.get(row.name, str(staged))
+            )
         if row.editable:
             value = self._record.get(row.name)
             if isinstance(value, dict):
@@ -199,6 +203,7 @@ class DetailScreen(Screen[None]):
         def _stage(result: tuple[int, str] | None) -> None:
             if result is not None:
                 self.staged[name] = result[0]
+                self._fk_labels[name] = result[1]
                 self._refresh_rows()
 
         self.app.push_screen(RecordPicker(self._client, target.list_op, target.current_id), _stage)
@@ -236,9 +241,12 @@ class DetailScreen(Screen[None]):
         self._table.focus()
 
     def _is_fk(self, name: str, spec: WidgetSpec) -> bool:
-        if spec.kind != "number" or spec.is_float or spec.sensitive:
+        # Writable FK fields type as oneOf[int, brief] -> UNKNOWN -> `text`, so a
+        # `number`-only gate would miss real relations. Key off the record's
+        # nested object instead; exclude enum/bool/secret/float.
+        if spec.kind in ("select", "switch", "masked") or spec.is_float:
             return False
-        return name.endswith("_id") or isinstance(self._record.get(name), dict)
+        return name.endswith("_id") or is_fk_value(self._record.get(name))
 
     # --- save ------------------------------------------------------------
     def action_save_all(self) -> None:
@@ -254,7 +262,7 @@ class DetailScreen(Screen[None]):
             if confirmed:
                 self._apply_patch(patch)
 
-        rows = diff_rows(self._record, patch, self._sensitive)
+        rows = diff_rows(self._record, patch, self._sensitive, self._fk_labels)
         self.app.push_screen(DiffModal(rows), _on_confirm)
 
     def _apply_patch(self, patch: dict[str, Any]) -> None:

--- a/nsc/tui/screens/edit_form.py
+++ b/nsc/tui/screens/edit_form.py
@@ -19,8 +19,15 @@ from nsc.http.errors import NetBoxAPIError, NetBoxClientError
 from nsc.model.command_model import CommandModel, Operation
 from nsc.tui._bindings import textual_bindings
 from nsc.tui.errors import api_error_message
-from nsc.tui.fk import resolve_fk_target
-from nsc.tui.forms import SET_NULL, WidgetSpec, compute_patch, diff_rows, field_to_widget
+from nsc.tui.fk import is_fk_value, resolve_fk_target
+from nsc.tui.forms import (
+    SET_NULL,
+    WidgetSpec,
+    compute_patch,
+    diff_rows,
+    field_to_widget,
+    fk_display,
+)
 from nsc.tui.view import detail_path
 
 
@@ -75,6 +82,7 @@ class EditForm(Screen[None]):
         self._op = operation
         self._record = record
         self._specs: dict[str, WidgetSpec] = {}
+        self._fk_labels: dict[str, str] = {}
         self.staged: dict[str, Any] = {}
         self._create_mode = operation.http_method.upper() == "POST"
         if self._create_mode:
@@ -119,9 +127,12 @@ class EditForm(Screen[None]):
         yield Input(value=text, password=spec.sensitive, id=f"field-{name}")
 
     def _is_fk(self, name: str, spec: WidgetSpec) -> bool:
-        if spec.kind != "number" or spec.is_float or spec.sensitive:
+        # Writable FK fields type as oneOf[int, brief] -> UNKNOWN -> `text`, so a
+        # `number`-only gate would miss real relations (role, site, tenant…). Key
+        # off the record's nested object instead; exclude enum/bool/secret/float.
+        if spec.kind in ("select", "switch", "masked") or spec.is_float:
             return False
-        return name.endswith("_id") or isinstance(self._record.get(name), dict)
+        return name.endswith("_id") or is_fk_value(self._record.get(name))
 
     def _compose_fk(self, name: str, value: Any) -> ComposeResult:
         target = resolve_fk_target(name, self._record.get(name), self._model)
@@ -131,7 +142,12 @@ class EditForm(Screen[None]):
             if target.hint:
                 yield Label(target.hint, classes="edit-fk-hint")
             return
-        current = "" if value is None else str(value)
+        nested = self._record.get(name)
+        current = (
+            fk_display(nested)
+            if isinstance(nested, dict)
+            else ("" if value is None else str(value))
+        )
         yield Button(f"{name}: {current}", id=f"fk-{name}", classes="edit-fk")
 
     @staticmethod
@@ -181,7 +197,10 @@ class EditForm(Screen[None]):
             self.action_save()
             return
         if ident.startswith("setnull-"):
-            self.staged[ident.removeprefix("setnull-")] = SET_NULL
+            field = ident.removeprefix("setnull-")
+            self.staged[field] = SET_NULL
+            # Drop any picked label so the diff can't show a name while nulling.
+            self._fk_labels.pop(field, None)
             return
         if ident.startswith("fk-"):
             self._open_picker(ident.removeprefix("fk-"))
@@ -195,6 +214,7 @@ class EditForm(Screen[None]):
         def _stage(result: tuple[int, str] | None) -> None:
             if result is not None:
                 self.staged[name] = result[0]
+                self._fk_labels[name] = result[1]
                 self.query_one(f"#fk-{name}", Button).label = f"{name}: {result[1]}"
 
         self.app.push_screen(RecordPicker(self._client, target.list_op, target.current_id), _stage)
@@ -212,7 +232,9 @@ class EditForm(Screen[None]):
             if confirmed:
                 self._apply_patch(patch, sensitive)
 
-        self.app.push_screen(DiffModal(diff_rows(self._record, patch, sensitive)), _on_confirm)
+        self.app.push_screen(
+            DiffModal(diff_rows(self._record, patch, sensitive, self._fk_labels)), _on_confirm
+        )
 
     def _apply_patch(self, patch: dict[str, Any], sensitive_paths: tuple[str, ...]) -> None:
         try:

--- a/tests/tui/test_bulk_diff.py
+++ b/tests/tui/test_bulk_diff.py
@@ -78,7 +78,15 @@ def test_fk_nested_dict_by_id_changes_when_id_differs() -> None:
     selected = [{"id": 1, "site": {"id": 9, "name": "dc1"}}]
     result = bulk_diff(selected, {"site": 3}, ())
     assert result[0].patch == {"site": 3}
-    assert result[0].rows == [DiffRow(field="site", old_display="9", new_display="3")]
+    # Old value renders the FK's human label, not its numeric id.
+    assert result[0].rows == [DiffRow(field="site", old_display="dc1", new_display="3")]
+
+
+def test_fk_new_display_override_renders_chosen_label() -> None:
+    selected = [{"id": 1, "site": {"id": 9, "name": "dc1"}}]
+    result = bulk_diff(selected, {"site": 3}, (), {"site": "dc2"})
+    assert result[0].patch == {"site": 3}
+    assert result[0].rows == [DiffRow(field="site", old_display="dc1", new_display="dc2")]
 
 
 def test_set_null_on_already_null_record_yields_no_row() -> None:

--- a/tests/tui/test_bulk_edit_form.py
+++ b/tests/tui/test_bulk_edit_form.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Input, Select, Static, Switch
+from textual.widgets import Button, Input, ListView, Select, Static, Switch
 
 from nsc.http.errors import NetBoxAPIError
 from nsc.model.command_model import (
@@ -19,6 +19,7 @@ from nsc.model.command_model import (
 from nsc.tui.forms import SET_NULL
 from nsc.tui.screens.bulk_edit_form import BulkEditForm
 from nsc.tui.screens.list import ListScreen
+from nsc.tui.screens.record_picker import RecordPicker
 from nsc.tui.widgets.bulk_diff import BulkDiffModal
 from nsc.tui.widgets.bulk_summary import BulkSummaryModal
 
@@ -574,3 +575,233 @@ async def test_success_returns_to_list_reloads_and_clears_selection() -> None:
         assert app.screen is list_screen
         assert len(list_screen.selection) == 0
         assert len(client.paginate_calls) > paginate_before
+
+
+# ---- foreign-key chooser (issue #97) ---------------------------------------
+#
+# Writable FK fields type as `oneOf[integer, brief-ref]` -> UNKNOWN primitive ->
+# `text` widget; the model carries no FK signal. Detection keys on the record's
+# runtime nested object, so the bulk form must show a chooser (not a raw-id box)
+# and render names in the diff.
+
+
+def _fk_model() -> CommandModel:
+    update_op = Operation(
+        operation_id="dcim_devices_partial_update",
+        http_method="PATCH",
+        path="/api/dcim/devices/{id}/",
+        request_body=RequestBodyShape(
+            top_level="object",
+            fields={
+                "status": FieldShape(primitive=PrimitiveType.STRING, enum=["active", "offline"]),
+                "role": FieldShape(primitive=PrimitiveType.UNKNOWN),
+            },
+        ),
+    )
+    devices = Resource(name="devices", update_op=update_op)
+    roles_list = Operation(
+        operation_id="dcim_device_roles_list",
+        http_method="GET",
+        path="/api/dcim/device-roles/",
+    )
+    roles = Resource(name="device-roles", list_op=roles_list)
+    tag = Tag(name="dcim", resources={"devices": devices, "device-roles": roles})
+    return CommandModel(info_title="t", info_version="1", schema_hash="h", tags={"dcim": tag})
+
+
+def _role(role_id: int, display: str) -> dict[str, Any]:
+    return {
+        "id": role_id,
+        "url": f"https://nb/api/dcim/device-roles/{role_id}/",
+        "display": display,
+    }
+
+
+def _fk_selected_shared() -> list[dict[str, Any]]:
+    role = _role(2, "Top of Rack Switch")
+    return [
+        {"id": 1, "status": "active", "role": role},
+        {"id": 2, "status": "active", "role": role},
+    ]
+
+
+def _fk_selected_hetero() -> list[dict[str, Any]]:
+    return [
+        {"id": 1, "status": "active", "role": _role(2, "Top of Rack Switch")},
+        {"id": 2, "status": "active", "role": _role(9, "Spine Switch")},
+    ]
+
+
+class _FkBulkApp(App[None]):
+    def __init__(self, client: _SpyClient, selected: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self._client = client
+        self._selected = selected
+
+    def compose(self) -> ComposeResult:
+        yield Static("")
+
+    async def on_mount(self) -> None:
+        model = _fk_model()
+        op = model.tags["dcim"].resources["devices"].update_op
+        assert op is not None
+        await self.push_screen(
+            BulkEditForm(model, self._client, "dcim", "devices", op, self._selected)
+        )
+
+
+@pytest.mark.asyncio
+async def test_fk_field_renders_chooser_button_seeded_with_shared_name() -> None:
+    client = _SpyClient([])
+    app = _FkBulkApp(client, _fk_selected_shared())
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        # A picker button, not a free-text id box.
+        button = screen.query_one("#fk-role", Button)
+        assert not screen.query("#field-role")
+        # Seeded with the shared FK's human label, not its id.
+        assert "Top of Rack Switch" in str(button.label)
+
+
+@pytest.mark.asyncio
+async def test_fk_pick_stages_id_updates_label_and_diff_shows_names() -> None:
+    client = _SpyClient([{"id": 5, "display": "Leaf Switch"}, {"id": 6, "display": "Spine"}])
+    app = _FkBulkApp(client, _fk_selected_shared())
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        screen.query_one("#fk-role", Button).press()
+        await pilot.pause()
+        picker = app.screen
+        assert isinstance(picker, RecordPicker)
+        picker.query_one(ListView).index = 0  # Leaf Switch -> id 5
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        # Picking alone does not opt the field in (consistent with other widgets).
+        assert screen.bulk_set == {}
+        screen.query_one("#include-role", Switch).value = True
+        await pilot.pause()
+        assert screen.bulk_set == {"role": 5}
+        assert "Leaf Switch" in str(screen.query_one("#fk-role", Button).label)
+        # Diff renders names on both sides, not ids; patch still carries the id.
+        screen.action_preview()
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, BulkDiffModal)
+        text = modal.render_text()
+        assert "Top of Rack Switch" in text
+        assert "Leaf Switch" in text
+        assert client.patch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_include_shared_fk_without_picking_uses_shared_id() -> None:
+    client = _SpyClient([])
+    app = _FkBulkApp(client, _fk_selected_shared())
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        screen.query_one("#include-role", Switch).value = True
+        await pilot.pause()
+        # Seeds from the shared id (a no-op against the records), never None.
+        assert screen.bulk_set == {"role": 2}
+
+
+@pytest.mark.asyncio
+async def test_include_heterogeneous_fk_without_picking_does_not_null() -> None:
+    client = _SpyClient([])
+    app = _FkBulkApp(client, _fk_selected_hetero())
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        # No shared value and nothing picked: must NOT inject None and null the FK.
+        screen.query_one("#include-role", Switch).value = True
+        await pilot.pause()
+        assert "role" not in screen.bulk_set
+
+
+@pytest.mark.asyncio
+async def test_pick_then_setnull_clears_label_so_diff_matches_patch() -> None:
+    # A nullable FK: pick a value (stages id + label), then ∅. The diff must show
+    # the null, never the stale picked name.
+    model = _fk_model()
+    body = model.tags["dcim"].resources["devices"].update_op.request_body
+    assert body is not None
+    body.fields["role"] = FieldShape(primitive=PrimitiveType.UNKNOWN, nullable=True)
+    client = _SpyClient([{"id": 5, "display": "Leaf Switch"}])
+
+    class _NullableApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("")
+
+        async def on_mount(self) -> None:
+            op = model.tags["dcim"].resources["devices"].update_op
+            assert op is not None
+            await self.push_screen(
+                BulkEditForm(model, client, "dcim", "devices", op, _fk_selected_shared())
+            )
+
+    app = _NullableApp()
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        screen.query_one("#fk-role", Button).press()
+        await pilot.pause()
+        picker = app.screen
+        assert isinstance(picker, RecordPicker)
+        picker.query_one(ListView).index = 0
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen._fk_labels.get("role") == "Leaf Switch"
+        screen.query_one("#setnull-role", Button).press()
+        await pilot.pause()
+        screen.query_one("#include-role", Switch).value = True
+        await pilot.pause()
+        assert screen.bulk_set.get("role") is SET_NULL
+        assert "role" not in screen._fk_labels
+        screen.action_preview()
+        await pilot.pause()
+        text = app.screen.render_text()
+        assert "Leaf Switch" not in text
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_fk_falls_back_to_raw_id_input() -> None:
+    # No matching list resource -> resolve_fk_target yields raw_id -> text box.
+    model = _fk_model()
+    model.tags["dcim"].resources.pop("device-roles")
+    selected = _fk_selected_shared()
+
+    class _RawApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("")
+
+        async def on_mount(self) -> None:
+            op = model.tags["dcim"].resources["devices"].update_op
+            assert op is not None
+            await self.push_screen(
+                BulkEditForm(model, _SpyClient([]), "dcim", "devices", op, selected)
+            )
+
+    app = _RawApp()
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, BulkEditForm)
+        widget = screen.query_one("#field-role")
+        assert isinstance(widget, Input)
+        assert not screen.query("#fk-role")
+        widget.value = "7"
+        await pilot.pause()
+        screen.query_one("#include-role", Switch).value = True
+        await pilot.pause()
+        assert screen.bulk_set == {"role": 7}
+        assert isinstance(screen.bulk_set["role"], int)

--- a/tests/tui/test_detail_screen.py
+++ b/tests/tui/test_detail_screen.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from textual.app import App, ComposeResult
 from textual.coordinate import Coordinate
-from textual.widgets import DataTable, Input, Static, Tab, Tabs
+from textual.widgets import DataTable, Input, ListView, Static, Tab, Tabs
 
 from nsc.http.errors import NetBoxAPIError
 from nsc.model.command_model import (
@@ -541,3 +541,93 @@ async def test_delete_reloads_underlying_list() -> None:
         await pilot.pause()
         assert isinstance(app.screen, ListScreen)
         assert app.client.paginate_count == before + 1
+
+
+# ---- text-kind FK detection + chosen-name display (issue #97) ---------------
+
+
+def _fk_model() -> CommandModel:
+    update_op = Operation(
+        operation_id="dcim_devices_partial_update",
+        http_method="PATCH",
+        path="/api/dcim/devices/{id}/",
+        request_body=RequestBodyShape(
+            top_level="object",
+            fields={"role": FieldShape(primitive=PrimitiveType.UNKNOWN)},
+        ),
+    )
+    devices = Resource(name="devices", update_op=update_op)
+    roles = Resource(
+        name="device-roles",
+        list_op=Operation(
+            operation_id="dcim_device_roles_list",
+            http_method="GET",
+            path="/api/dcim/device-roles/",
+        ),
+    )
+    tag = Tag(name="dcim", resources={"devices": devices, "device-roles": roles})
+    return CommandModel(info_title="t", info_version="1", schema_hash="h", tags={"dcim": tag})
+
+
+class _FkPickClient(_SpyClient):
+    def paginate(
+        self, path: str, params: dict[str, Any] | None = None, *, limit: int | None = None
+    ) -> Any:
+        return iter([{"id": 9, "display": "Leaf Switch"}])
+
+
+class _FkDetailApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.client = _FkPickClient()
+
+    def compose(self) -> ComposeResult:
+        yield Static("")
+
+    async def on_mount(self) -> None:
+        model = _fk_model()
+        resource = model.tags["dcim"].resources["devices"]
+        record = {
+            "id": 7,
+            "role": {
+                "id": 2,
+                "url": "https://nb/api/dcim/device-roles/2/",
+                "display": "Top of Rack Switch",
+            },
+        }
+        await self.push_screen(
+            DetailScreen(model, self.client, "dcim", "devices", resource, record)
+        )
+
+
+@pytest.mark.asyncio
+async def test_text_kind_fk_opens_picker_and_shows_chosen_name() -> None:
+    app = _FkDetailApp()
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = _detail(app)
+        screen._table.move_cursor(row=0)  # the "role" FK field
+        screen.action_edit_field()
+        await pilot.pause()
+        # UNKNOWN-primitive FK is detected from the nested value -> picker, not text input.
+        picker = app.screen
+        assert isinstance(picker, RecordPicker)
+        picker.query_one(ListView).index = 0  # Leaf Switch -> id 9
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen.staged.get("role") == 9
+        # The table renders the chosen name, not the bare id.
+        rendered = [
+            str(screen._table.get_cell_at(Coordinate(r, 1))) for r in range(screen._table.row_count)
+        ]
+        assert any("Leaf Switch" in cell for cell in rendered)
+        # The save diff renders the name on both sides.
+        screen.action_save_all()
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, DiffModal)
+        rows = modal._rows
+        role_row = next(r for r in rows if r.field == "role")
+        assert role_row.old_display == "Top of Rack Switch"
+        assert role_row.new_display == "Leaf Switch"

--- a/tests/tui/test_diff.py
+++ b/tests/tui/test_diff.py
@@ -81,13 +81,14 @@ def test_diff_rows_set_null_shows_none() -> None:
     assert rows == [DiffRow(field="comments", old_display="hi", new_display="None")]
 
 
-def test_diff_rows_nested_fk_old_display_uses_id() -> None:
+def test_diff_rows_nested_fk_old_display_uses_name() -> None:
+    # Issue #97: the old value renders the FK's human label, not its numeric id.
     original = {"site": {"id": 5, "name": "AMS1"}}
     staged = {"site": 7}
     patch = compute_patch(original, staged)
     rows = diff_rows(original, patch, sensitive_paths=())
     assert rows[0].field == "site"
-    assert "5" in rows[0].old_display
+    assert rows[0].old_display == "AMS1"
     assert rows[0].new_display == "7"
 
 

--- a/tests/tui/test_edit_form.py
+++ b/tests/tui/test_edit_form.py
@@ -245,6 +245,59 @@ async def test_fk_control_opens_record_picker() -> None:
 
 
 @pytest.mark.asyncio
+async def test_text_kind_fk_is_detected_from_nested_record_value() -> None:
+    # Real writable FK fields type as oneOf[int, brief] -> UNKNOWN -> `text`.
+    # Detection must key off the record's nested object, not a `number` kind.
+    update_op = Operation(
+        operation_id="dcim_devices_partial_update",
+        http_method="PATCH",
+        path="/api/dcim/devices/{id}/",
+        request_body=RequestBodyShape(
+            top_level="object",
+            fields={"role": FieldShape(primitive=PrimitiveType.UNKNOWN)},
+        ),
+    )
+    devices = Resource(name="devices", update_op=update_op)
+    roles = Resource(
+        name="device-roles",
+        list_op=Operation(
+            operation_id="dcim_device_roles_list",
+            http_method="GET",
+            path="/api/dcim/device-roles/",
+        ),
+    )
+    tag = Tag(name="dcim", resources={"devices": devices, "device-roles": roles})
+    model = CommandModel(info_title="t", info_version="1", schema_hash="h", tags={"dcim": tag})
+    record = {
+        "id": 5,
+        "role": {
+            "id": 2,
+            "url": "https://nb/api/dcim/device-roles/2/",
+            "display": "Top of Rack Switch",
+        },
+    }
+
+    class _RoleApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("")
+
+        async def on_mount(self) -> None:
+            await self.push_screen(
+                EditForm(model, _SpyClient([]), "dcim", "devices", update_op, record)
+            )
+
+    app = _RoleApp()
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, EditForm)
+        # Renders a chooser button (not a free-text id box) and seeds the name.
+        button = screen.query_one("#fk-role", Button)
+        assert "Top of Rack Switch" in str(button.label)
+        assert not screen.query("#field-role")
+
+
+@pytest.mark.asyncio
 async def test_save_pushes_diff_modal_with_only_changed_field() -> None:
 
     client = _SpyClient([])

--- a/tests/tui/test_fk_resolve.py
+++ b/tests/tui/test_fk_resolve.py
@@ -105,6 +105,20 @@ def test_unknown_url_resource_falls_back_to_raw_id() -> None:
     assert "widget" in target.hint
 
 
+def test_url_resource_without_list_op_falls_back_to_raw_id() -> None:
+    # The resource exists but has no list endpoint, so a chooser is impossible;
+    # `kind="picker"` must never carry a None list_op (it would be a dead button).
+    sites = Resource(name="sites", list_op=None)
+    dcim = Tag(name="dcim", resources={"sites": sites})
+    model = CommandModel(info_title="t", info_version="1", schema_hash="h", tags={"dcim": dcim})
+    value = {"id": 3, "url": "https://nb/api/dcim/sites/3/"}
+    target = resolve_fk_target("site", value, model)
+    assert target.kind == "raw_id"
+    assert target.list_op is None
+    assert target.current_id == 3
+    assert target.hint
+
+
 def test_unknown_field_name_falls_back_to_raw_id() -> None:
     target = resolve_fk_target("gizmo_id", None, _model())
     assert target.kind == "raw_id"

--- a/tests/tui/test_forms.py
+++ b/tests/tui/test_forms.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from nsc.model.command_model import FieldShape, PrimitiveType
-from nsc.tui.forms import WidgetSpec, field_to_widget
+from nsc.tui.forms import DiffRow, WidgetSpec, diff_rows, field_to_widget, fk_display
 
 
 def test_enum_maps_to_select_carrying_choices() -> None:
@@ -88,3 +88,45 @@ def test_widget_spec_is_frozen() -> None:
     assert isinstance(spec, WidgetSpec)
     with pytest.raises(ValidationError):
         spec.kind = "select"  # type: ignore[misc]
+
+
+def test_fk_display_prefers_display_over_id() -> None:
+    assert fk_display({"id": 12, "display": "Top of Rack Switch", "name": "tor"}) == (
+        "Top of Rack Switch"
+    )
+
+
+def test_fk_display_falls_back_to_name_then_slug_then_id() -> None:
+    assert fk_display({"id": 12, "name": "tor", "slug": "tor-sw"}) == "tor"
+    assert fk_display({"id": 12, "slug": "tor-sw"}) == "tor-sw"
+    assert fk_display({"id": 12}) == "12"
+
+
+def test_fk_display_ignores_empty_label_values() -> None:
+    # An empty/None label must not shadow a usable lower-priority one.
+    assert fk_display({"id": 12, "display": "", "name": "tor"}) == "tor"
+    assert fk_display({"id": 12, "display": None, "name": None}) == "12"
+
+
+def test_fk_display_passes_through_non_dict() -> None:
+    assert fk_display("active") == "active"
+    assert fk_display(7) == "7"
+
+
+def test_diff_rows_renders_fk_old_value_as_name() -> None:
+    original = {"role": {"id": 12, "display": "Top of Rack Switch"}}
+    rows = diff_rows(original, {"role": 5}, ())
+    assert rows == [DiffRow(field="role", old_display="Top of Rack Switch", new_display="5")]
+
+
+def test_diff_rows_new_display_override_used_for_new_value() -> None:
+    original = {"role": {"id": 12, "display": "Top of Rack Switch"}}
+    rows = diff_rows(original, {"role": 5}, (), {"role": "Leaf Switch"})
+    assert rows == [
+        DiffRow(field="role", old_display="Top of Rack Switch", new_display="Leaf Switch")
+    ]
+
+
+def test_diff_rows_override_absent_falls_back_to_str() -> None:
+    rows = diff_rows({"status": "active"}, {"status": "offline"}, (), {"role": "x"})
+    assert rows == [DiffRow(field="status", old_display="active", new_display="offline")]


### PR DESCRIPTION
Closes #97.

## Problem

In the TUI bulk-edit flow, foreign-key fields (device `role`, `site`, `tenant`, `device_type`, …) showed the raw numeric **id** and were edited as **free-text**, with no dropdown of valid related objects.

Root cause found while implementing: NetBox's writable serializers type FK fields as `oneOf[integer, brief-ref]` with **no top-level `type`**, so the builder assigns `UNKNOWN` and `field_to_widget` returns a `text` widget. FK detection therefore **cannot** key on the `number` widget kind (the existing `EditForm`/`DetailScreen` `_is_fk` did, so they were subtly wrong for real schemas too). The reliable signal is the record's nested FK object.

## Changes

Pure layer (`nsc/tui/forms.py`, `nsc/tui/bulk.py`, `nsc/tui/fk.py`):
- `forms.fk_display` — render an FK nested object by `display` → `name` → `slug`, falling back to `id` (was always `id`). Drives the diff's **old** value.
- `forms.diff_rows` / `bulk.bulk_diff` — optional `new_displays` to render a picked FK's chosen label as the **new** value. The patch still carries the id (wire format unchanged).
- `fk.is_fk_value` — shared runtime FK test (nested dict carrying `id`/`url`), excluding bare `custom_fields` dicts.

Screens:
- **BulkEditForm** — FK fields render a record-picker chooser (resolved via `nsc/tui/fk.py` + `relations.py`), seeded with the shared FK name; the diff shows names on both sides. Unresolvable targets fall back to a raw-id box. Opting a picker FK in with no shared value and no pick **never nulls** the relation.
- **EditForm** / **DetailScreen** — same loosened FK detection + chosen-name rendering in the button / table / diff.
- Clearing a field via ∅ drops any stale picked label so the diff can't show a name while the patch nulls the relation.

## Tests

TDD throughout. New coverage in `test_forms.py`, `test_bulk_diff.py`, `test_diff.py`, `test_bulk_edit_form.py`, `test_edit_form.py`, `test_detail_screen.py`: name-over-id display, `new_displays` override, text-kind (UNKNOWN) FK detection, picker staging + label update, diff name rendering, shared-vs-heterogeneous opt-in safety, raw-id fallback, and pick-then-null label clearing.

Full suite: `1078 passed, 1 skipped`. `just lint` clean (ruff + `mypy --strict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)