### PR TITLE
feat: curated singular alias forms (`nsc ls device`)

### DIFF
--- a/nsc/aliases/__init__.py
+++ b/nsc/aliases/__init__.py
@@ -8,17 +8,21 @@ rule as `nsc.model`. Consumers (`nsc/cli/aliases_commands.py`) call
 from __future__ import annotations
 
 from nsc.aliases.resolver import (
+    CURATED_SINGULARS,
     AliasVerb,
     AmbiguousAlias,
     ResolvedAlias,
     UnknownAlias,
     resolve,
+    suggest_plural,
 )
 
 __all__ = [
+    "CURATED_SINGULARS",
     "AliasVerb",
     "AmbiguousAlias",
     "ResolvedAlias",
     "UnknownAlias",
     "resolve",
+    "suggest_plural",
 ]

--- a/nsc/aliases/resolver.py
+++ b/nsc/aliases/resolver.py
@@ -21,6 +21,22 @@ class AliasVerb(StrEnum):
     SEARCH = "search"
 
 
+CURATED_SINGULARS: dict[str, str] = {
+    "device": "devices",
+    "prefix": "prefixes",
+    "tenant": "tenants",
+    "vlan": "vlans",
+    "site": "sites",
+    "rack": "racks",
+    "interface": "interfaces",
+    "cable": "cables",
+    "tag": "tags",
+}
+"""Hand-picked singular→plural forms. Deliberately small: irregular plurals
+(`prefix`→`prefixes`) and high-traffic resources only. Anything outside this
+map is left to the `suggest_plural` hint at the error layer, never auto-resolved."""
+
+
 class _Frozen(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -61,17 +77,11 @@ def _resolve_term(
     verb: AliasVerb, term: str, model: CommandModel
 ) -> ResolvedAlias | AmbiguousAlias | UnknownAlias:
     needle = term.lower()
-    candidates: list[tuple[str, str, Operation]] = []
-    for tag_name in sorted(model.tags):
-        tag = model.tags[tag_name]
-        for resource_name in sorted(tag.resources):
-            if resource_name.lower() != needle:
-                continue
-            resource = tag.resources[resource_name]
-            op = _required_op_for(verb, resource)
-            if op is None:
-                continue
-            candidates.append((tag_name, resource_name, op))
+    candidates = _match_resources(verb, needle, model)
+    # Literal resource names win; only retry the curated plural when the
+    # singular itself matched nothing (so a real `device` resource is honored).
+    if not candidates and needle in CURATED_SINGULARS:
+        candidates = _match_resources(verb, CURATED_SINGULARS[needle], model)
     if len(candidates) == 1:
         tag_name, resource_name, op = candidates[0]
         return ResolvedAlias(tag=tag_name, resource_name=resource_name, operation=op)
@@ -82,6 +92,35 @@ def _resolve_term(
             candidates=[(t, r) for t, r, _ in candidates],
         )
     return UnknownAlias(verb=verb, term=term)
+
+
+def _match_resources(
+    verb: AliasVerb, needle: str, model: CommandModel
+) -> list[tuple[str, str, Operation]]:
+    candidates: list[tuple[str, str, Operation]] = []
+    for tag_name in sorted(model.tags):
+        tag = model.tags[tag_name]
+        for resource_name in sorted(tag.resources):
+            if resource_name.lower() != needle:
+                continue
+            op = _required_op_for(verb, tag.resources[resource_name])
+            if op is None:
+                continue
+            candidates.append((tag_name, resource_name, op))
+    return candidates
+
+
+def suggest_plural(verb: AliasVerb, term: str, model: CommandModel) -> str | None:
+    """For a singular term that didn't resolve, propose `term + 's'` IFF that
+    pluralized name resolves to a real resource for `verb`. Pure/deterministic;
+    the error layer uses it to render a "Did you mean ...?" hint."""
+    lowered = term.lower()
+    if lowered.endswith("s"):
+        return None
+    plural = lowered + "s"
+    if _match_resources(verb, plural, model):
+        return plural
+    return None
 
 
 def _required_op_for(verb: AliasVerb, resource: Resource) -> Operation | None:

--- a/nsc/cli/aliases_commands.py
+++ b/nsc/cli/aliases_commands.py
@@ -19,6 +19,7 @@ from nsc.aliases import (
     ResolvedAlias,
     UnknownAlias,
     resolve,
+    suggest_plural,
 )
 from nsc.cli.handlers import handle_delete, handle_get, handle_list
 from nsc.cli.runtime import RuntimeContext, emit_envelope
@@ -119,7 +120,12 @@ def register(app: typer.Typer) -> None:  # noqa: PLR0915
             env = ambiguous_alias_envelope(verb="ls", term=term, candidates=result.candidates)
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         if isinstance(result, UnknownAlias):
-            env = unknown_alias_envelope(verb="ls", term=term, reason=result.reason)
+            env = unknown_alias_envelope(
+                verb="ls",
+                term=term,
+                reason=result.reason,
+                suggestion=suggest_plural(AliasVerb.LS, term, runtime.command_model),
+            )
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         assert isinstance(result, ResolvedAlias)
         handle_list(
@@ -154,7 +160,12 @@ def register(app: typer.Typer) -> None:  # noqa: PLR0915
             env = ambiguous_alias_envelope(verb="rm", term=term, candidates=result.candidates)
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         if isinstance(result, UnknownAlias):
-            env = unknown_alias_envelope(verb="rm", term=term, reason=result.reason)
+            env = unknown_alias_envelope(
+                verb="rm",
+                term=term,
+                reason=result.reason,
+                suggestion=suggest_plural(AliasVerb.RM, term, runtime.command_model),
+            )
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         assert isinstance(result, ResolvedAlias)
 
@@ -204,7 +215,12 @@ def register(app: typer.Typer) -> None:  # noqa: PLR0915
             env = ambiguous_alias_envelope(verb="get", term=term, candidates=result.candidates)
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         if isinstance(result, UnknownAlias):
-            env = unknown_alias_envelope(verb="get", term=term, reason=result.reason)
+            env = unknown_alias_envelope(
+                verb="get",
+                term=term,
+                reason=result.reason,
+                suggestion=suggest_plural(AliasVerb.GET, term, runtime.command_model),
+            )
             raise typer.Exit(_emit_alias_envelope(env, runtime))
         assert isinstance(result, ResolvedAlias)
 

--- a/nsc/output/errors.py
+++ b/nsc/output/errors.py
@@ -205,6 +205,7 @@ def unknown_alias_envelope(
     verb: str,
     term: str,
     reason: str = "no_such_resource",
+    suggestion: str | None = None,
 ) -> ErrorEnvelope:
     """Build the envelope for an alias term that resolves to zero resources.
 
@@ -212,6 +213,10 @@ def unknown_alias_envelope(
     suggests `nsc commands` for resource discovery. `reason="search_endpoint_unavailable"`
     is the search-specific case (schema does not expose `/api/search/`); the
     message must not suggest `nsc commands` since that wouldn't help.
+
+    `suggestion` is an optional resource name (e.g. the pluralized form) that
+    actually resolves; when present it is appended as a "Did you mean ...?" hint
+    and surfaced in `details.suggestion` for JSON consumers.
     """
     if reason == "search_endpoint_unavailable":
         message = (
@@ -223,10 +228,14 @@ def unknown_alias_envelope(
             f"unknown resource `{term}` for `nsc {verb}`; "
             f"run `nsc commands` to list known resources"
         )
+    details: dict[str, Any] = {"verb": verb, "term": term, "reason": reason}
+    if suggestion is not None:
+        message = f"{message}. Did you mean `{suggestion}`?"
+        details["suggestion"] = suggestion
     return ErrorEnvelope(
         error=message,
         type=ErrorType.UNKNOWN_ALIAS,
-        details={"verb": verb, "term": term, "reason": reason},
+        details=details,
     )
 
 

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -218,8 +218,11 @@ indefinitely until manually refreshed), `weekly` (7-day TTL).
   change with NetBox versions.
 - DO NOT authenticate per-command. Configure a profile (`nsc init` then
   `nsc login`) once at session start; `--profile <name>` switches between them.
-- DO NOT assume singular resource names. Plural-only is the v1 stance:
-  `nsc ls devices`, not `nsc ls device`.
+- DO NOT assume every resource name has a singular alias. Resource names are
+  plural (`nsc ls devices`). Curated singular forms also work for the common
+  resources — `device, prefix, tenant, vlan, site, rack, interface, cable, tag`
+  (so `nsc ls device` == `nsc ls devices`) — but outside that list, use the
+  plural. An unknown singular suggests its plural when one exists.
 
 ## Profile management
 

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -26,6 +26,8 @@ nsc <tag> <resource> <verb> [args] [--apply] [--output json]
 
 - `<tag>` — the OpenAPI tag, e.g., `dcim`, `ipam`, `tenancy`, `circuits`, `extras`.
 - `<resource>` — plural form, e.g., `devices`, `prefixes`, `tenants`, `vlans`.
+  Curated singular forms are also accepted for common resources (`device`,
+  `prefix`, `tenant`, `vlan`, `site`, `rack`, `interface`, `cable`, `tag`).
 - `<verb>` — reads: `list`, `get`. Writes: `create`, `update`, `replace`,
   `delete`, plus any custom actions the schema exposes. `replace` is a
   PUT-with-id (full-object) replace; `update` is a PATCH. (Bulk variants exist

--- a/tests/aliases/test_resolver.py
+++ b/tests/aliases/test_resolver.py
@@ -149,6 +149,18 @@ def test_resolve_ls_ambiguous_across_two_tags() -> None:
     assert result.candidates == [("plugin_a", "widgets"), ("plugin_b", "widgets")]
 
 
+def test_resolve_curated_singular_ambiguous_across_two_tags() -> None:
+    """Curated `device` retries as `devices`; if that exists under >=2 tags it is ambiguous."""
+    model = _model(
+        Tag(name="plugin_a", resources={"devices": _read_only_resource("devices", "plugin_a")}),
+        Tag(name="plugin_b", resources={"devices": _read_only_resource("devices", "plugin_b")}),
+    )
+    result = resolve(AliasVerb.LS, "device", model)
+    assert isinstance(result, AmbiguousAlias)
+    assert result.term == "device"
+    assert result.candidates == [("plugin_a", "devices"), ("plugin_b", "devices")]
+
+
 def test_resolve_rm_skips_resources_without_delete_op() -> None:
     """A resource that has list_op but no delete_op cannot match `rm`.
 

--- a/tests/aliases/test_resolver.py
+++ b/tests/aliases/test_resolver.py
@@ -16,6 +16,7 @@ from nsc.aliases import (
     ResolvedAlias,
     UnknownAlias,
     resolve,
+    suggest_plural,
 )
 from nsc.model.command_model import (
     CommandModel,
@@ -79,12 +80,55 @@ def test_resolve_ls_is_case_insensitive() -> None:
     assert isinstance(resolve(AliasVerb.LS, "Devices", model), ResolvedAlias)
 
 
-def test_resolve_ls_does_not_pluralize_singular_input() -> None:
-    """Spec §11: plural-only is the v1 stance. `device` must NOT match `devices`."""
+def test_resolve_ls_curated_singular_resolves_to_plural() -> None:
+    """Issue #6: curated singular `device` resolves like `devices`."""
     model = _model(Tag(name="dcim", resources={"devices": _devices_resource()}))
     result = resolve(AliasVerb.LS, "device", model)
+    assert isinstance(result, ResolvedAlias)
+    assert result.resource_name == "devices"
+    assert result.operation.operation_id == "dcim_devices_list"
+
+
+def test_resolve_curated_singular_is_case_insensitive() -> None:
+    model = _model(Tag(name="dcim", resources={"devices": _devices_resource()}))
+    assert isinstance(resolve(AliasVerb.LS, "Device", model), ResolvedAlias)
+    assert isinstance(resolve(AliasVerb.LS, "DEVICE", model), ResolvedAlias)
+
+
+def test_resolve_curated_singular_works_for_get_and_rm() -> None:
+    model = _model(Tag(name="dcim", resources={"devices": _devices_resource()}))
+    get_result = resolve(AliasVerb.GET, "device", model)
+    assert isinstance(get_result, ResolvedAlias)
+    assert get_result.operation.operation_id == "dcim_devices_retrieve"
+    rm_result = resolve(AliasVerb.RM, "device", model)
+    assert isinstance(rm_result, ResolvedAlias)
+    assert rm_result.operation.http_method is HttpMethod.DELETE
+
+
+def test_resolve_curated_singular_unknown_when_plural_absent() -> None:
+    """`tag` is curated but if no `tags` resource exists, still UnknownAlias."""
+    model = _model(Tag(name="dcim", resources={"devices": _devices_resource()}))
+    result = resolve(AliasVerb.LS, "tag", model)
     assert isinstance(result, UnknownAlias)
-    assert result.term == "device"
+    assert result.term == "tag"
+
+
+def test_resolve_literal_match_wins_over_curated_pluralization() -> None:
+    """A resource literally named `device` matches before the curated retry."""
+    literal = _read_only_resource("device", "dcim")
+    model = _model(Tag(name="dcim", resources={"device": literal}))
+    result = resolve(AliasVerb.LS, "device", model)
+    assert isinstance(result, ResolvedAlias)
+    assert result.resource_name == "device"
+
+
+def test_resolve_non_curated_singular_does_not_pluralize() -> None:
+    """Non-curated singular must NOT auto-pluralize in the resolver."""
+    widgets = _read_only_resource("widgets", "dcim")
+    model = _model(Tag(name="dcim", resources={"widgets": widgets}))
+    result = resolve(AliasVerb.LS, "widget", model)
+    assert isinstance(result, UnknownAlias)
+    assert result.term == "widget"
 
 
 def test_resolve_ls_unknown_when_no_resource_named_term() -> None:
@@ -181,6 +225,28 @@ def test_resolve_search_unknown_when_endpoint_missing() -> None:
     result = resolve(AliasVerb.SEARCH, "anything", model)
     assert isinstance(result, UnknownAlias)
     assert result.reason == "search_endpoint_unavailable"
+
+
+def test_suggest_plural_returns_plural_when_it_resolves() -> None:
+    """`rack` (non-curated singular here) → `racks` only if `racks` resolves."""
+    racks = _read_only_resource("racks", "dcim")
+    model = _model(Tag(name="dcim", resources={"racks": racks}))
+    assert suggest_plural(AliasVerb.LS, "widget", model) is None
+    assert suggest_plural(AliasVerb.LS, "rack", model) == "racks"
+
+
+def test_suggest_plural_none_when_already_plural() -> None:
+    """An s-terminated term is not re-pluralized."""
+    racks = _read_only_resource("racks", "dcim")
+    model = _model(Tag(name="dcim", resources={"racks": racks}))
+    assert suggest_plural(AliasVerb.LS, "racks", model) is None
+
+
+def test_suggest_plural_respects_verb_required_op() -> None:
+    """No suggestion if the pluralized resource lacks the required op for the verb."""
+    racks = _read_only_resource("racks", "dcim")
+    model = _model(Tag(name="dcim", resources={"racks": racks}))
+    assert suggest_plural(AliasVerb.RM, "rack", model) is None
 
 
 def test_resolve_search_ignores_non_get_search_paths() -> None:

--- a/tests/cli/test_aliases_commands.py
+++ b/tests/cli/test_aliases_commands.py
@@ -46,6 +46,20 @@ def test_ls_devices_invokes_list_endpoint() -> None:
 
 
 @respx.mock
+def test_ls_curated_singular_device_invokes_list_endpoint() -> None:
+    _mock_schema(respx.mock)
+    route = respx.get("https://nb.example/api/dcim/devices/").mock(
+        return_value=httpx.Response(
+            200, json={"count": 0, "next": None, "previous": None, "results": []}
+        )
+    )
+    result = CliRunner().invoke(app, ["ls", "device", "--output", "json"])
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert route.called
+    assert json.loads(result.stdout) == []
+
+
+@respx.mock
 def test_ls_unknown_resource_exits_14() -> None:
     _mock_schema(respx.mock)
     result = CliRunner().invoke(app, ["ls", "nonexistent", "--output", "json"])
@@ -53,6 +67,17 @@ def test_ls_unknown_resource_exits_14() -> None:
     payload = json.loads(result.stdout)
     assert payload["type"] == "unknown_alias"
     assert payload["details"]["term"] == "nonexistent"
+
+
+@respx.mock
+def test_ls_non_curated_singular_suggests_plural() -> None:
+    """`nsc ls power-panel` (not curated) → unknown, but suggests `power-panels`."""
+    _mock_schema(respx.mock)
+    result = CliRunner().invoke(app, ["ls", "power-panel", "--output", "json"])
+    assert result.exit_code == 14, (result.exit_code, result.stdout)
+    payload = json.loads(result.stdout)
+    assert payload["details"]["suggestion"] == "power-panels"
+    assert "Did you mean `power-panels`?" in payload["error"]
 
 
 @respx.mock

--- a/tests/output/test_errors_aliases.py
+++ b/tests/output/test_errors_aliases.py
@@ -74,6 +74,20 @@ def test_unknown_alias_envelope_for_missing_resource() -> None:
     assert "nsc commands" in payload["error"]
 
 
+def test_unknown_alias_envelope_with_suggestion() -> None:
+    env = unknown_alias_envelope(verb="ls", term="widget", suggestion="widgets")
+    payload = json.loads(render_to_json(env))
+    assert payload["details"]["suggestion"] == "widgets"
+    assert "Did you mean `widgets`?" in payload["error"]
+
+
+def test_unknown_alias_envelope_without_suggestion_omits_field() -> None:
+    env = unknown_alias_envelope(verb="ls", term="widget")
+    payload = json.loads(render_to_json(env))
+    assert "suggestion" not in payload["details"]
+    assert "Did you mean" not in payload["error"]
+
+
 def test_unknown_alias_envelope_for_missing_search_endpoint() -> None:
     env = unknown_alias_envelope(
         verb="search",


### PR DESCRIPTION
Closes #6

## What

Adds curated singular alias forms to the `ls`/`get`/`rm` resolver so `nsc ls device` works identically to `nsc ls devices`.

- **Curated singular→plural map** (`CURATED_SINGULARS`) in the pure resolver: `device, prefix, tenant, vlan, site, rack, interface, cable, tag`.
- `_resolve_term` first tries the literal term, then — only if nothing matched **and** the lowercased term is a curated singular — retries with the plural. So a real resource literally named `device` still wins over the curated retry (no behavior surprise).
- Works across `ls`/`get`/`rm` since the retry goes through the same verb-required-op gating.
- **"Did you mean `<plural>`?" suggestion** for non-curated singulars: a pure `suggest_plural(verb, term, model)` helper returns `term + "s"` only when that pluralized name actually resolves to a real resource for the verb. The error-rendering layer (`unknown_alias_envelope`) threads it into the message and `details.suggestion`. The resolver stays framework-free; the suggestion is computed where the error is shown.
- Updated bundled `skills/netbox-super-cli/SKILL.md` "What NOT to do" to note curated singular forms also work.

## Tests

- Resolver: curated singular resolves to plural (ls/get/rm, case-insensitive); literal name wins over curated; non-curated singular does not auto-resolve; curated singular still Unknown when the plural resource is absent; `suggest_plural` returns plural only when it resolves, respects verb-required-op, and is None for already-plural terms.
- Errors: `unknown_alias_envelope` suggestion text + `details.suggestion`; omitted when no suggestion.
- CLI integration: `nsc ls device` hits the devices endpoint; `nsc ls power-panel` (non-curated) exits 14 with `Did you mean \`power-panels\`?`.
- Full suite: 1091 passed, 1 skipped. `ruff` + `mypy --strict` clean.

## Reviewer notes / risks

- **Collision semantics**: if a NetBox schema ever literally names a resource `device` (singular), the literal match wins and the curated retry never fires — intended, but worth a glance.
- The curated retry can surface `AmbiguousAlias` if the plural exists under ≥2 tags (e.g. `interfaces` in `dcim` and a plugin). That mirrors existing plural behavior; the singular just inherits it.
- `suggest_plural` uses naive `+ "s"`, so it won't suggest irregular plurals (e.g. `prefix`→`prefixes`) for non-curated terms — but those irregulars are exactly the ones in the curated map, which resolve directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)