### PR TITLE
fix: harden ~/.nsc state-root directory to 0700

### DIFF
--- a/nsc/config/settings.py
+++ b/nsc/config/settings.py
@@ -3,8 +3,40 @@
 from __future__ import annotations
 
 import os
+import stat
 from dataclasses import dataclass
 from pathlib import Path
+
+# The nsc state tree (`~/.nsc` and everything under it) holds config tokens,
+# audit bodies, and cached schemas; keep every directory we create owner-only,
+# mirroring the 0600 file treatment in writer.py / audit.py.
+_DIR_MODE = 0o700
+
+
+def ensure_private_dir(directory: Path) -> None:
+    """Create `directory` (with parents) and clamp the created chain to 0700.
+
+    Every directory this call brings into existence — including an intermediate
+    `~/.nsc` root that would otherwise inherit umask (~0755) — is set owner-only.
+    A pre-existing leaf that is group/world-accessible is tightened too, so a
+    `~/.nsc/logs` left 0755 by an older nsc version is fixed in place; but an
+    already-restrictive leaf is left alone so a deliberately read-only dir still
+    surfaces a write failure rather than being silently reopened. Pre-existing
+    ancestors (e.g. `$HOME`) are never touched.
+    """
+    missing: list[Path] = []
+    cursor = directory
+    while not cursor.exists():
+        missing.append(cursor)
+        parent = cursor.parent
+        if parent == cursor:
+            break
+        cursor = parent
+    directory.mkdir(parents=True, exist_ok=True)
+    for created in missing:
+        os.chmod(created, _DIR_MODE)
+    if directory not in missing and stat.S_IMODE(directory.stat().st_mode) & 0o077:
+        os.chmod(directory, _DIR_MODE)
 
 
 @dataclass(frozen=True, slots=True)

--- a/nsc/config/writer.py
+++ b/nsc/config/writer.py
@@ -27,6 +27,8 @@ from ruamel.yaml.comments import CommentedMap, TaggedScalar
 from ruamel.yaml.constructor import BaseConstructor
 from ruamel.yaml.nodes import ScalarNode
 
+from nsc.config.settings import ensure_private_dir
+
 _log = logging.getLogger(__name__)
 _FILE_MODE = 0o600
 
@@ -39,7 +41,7 @@ def atomic_write(path: Path, text: str) -> None:
     before or during `os.replace`, the original file is untouched and
     the temp file is cleaned up.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_private_dir(path.parent)
     fd, tmp_path = tempfile.mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
@@ -69,7 +71,7 @@ def acquire_lock(path: Path) -> Iterator[None]:
     truncate the target file via locking.
     """
     lock_path = path.with_suffix(path.suffix + ".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_private_dir(lock_path.parent)
     try:
         import fcntl  # noqa: PLC0415  # platform-conditional: absent on Windows.
     except ImportError:

--- a/nsc/http/audit.py
+++ b/nsc/http/audit.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import copy
 import json
 import os
-import stat
 import sys
 import tempfile
 from collections.abc import Sequence
@@ -22,6 +21,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from nsc.config.settings import ensure_private_dir
 from nsc.model.command_model import HttpMethod
 from nsc.output.headers import SENSITIVE_HEADERS
 
@@ -31,7 +31,6 @@ SCHEMA_VERSION = 1
 
 # Audit logs hold request/response bodies verbatim; keep them owner-only,
 # mirroring the 0600 treatment of config.yaml in nsc/config/writer.py.
-_DIR_MODE = 0o700
 _FILE_MODE = 0o600
 
 
@@ -156,23 +155,10 @@ def _warn(msg: str) -> None:
     print(f"warning: {msg}", file=sys.stderr)
 
 
-def _ensure_private_dir(directory: Path) -> None:
-    """Ensure `directory` exists and is owner-only.
-
-    Tightens an existing world/group-accessible dir too (e.g. a `~/.nsc/logs`
-    left 0755 by an older nsc version or a permissive umask), but leaves an
-    already-restrictive dir alone so a deliberately read-only dir still surfaces
-    a write failure rather than being silently reopened.
-    """
-    directory.mkdir(parents=True, exist_ok=True)
-    if stat.S_IMODE(directory.stat().st_mode) & 0o077:
-        os.chmod(directory, _DIR_MODE)
-
-
 def write_last_request(entry: AuditEntry, *, path: Path) -> None:
     """Atomically overwrite `path` with the entry. Failures emit a stderr warning."""
     try:
-        _ensure_private_dir(path.parent)
+        ensure_private_dir(path.parent)
         with tempfile.NamedTemporaryFile(
             "w", encoding="utf-8", dir=path.parent, delete=False
         ) as tmp:
@@ -192,7 +178,7 @@ def append_audit_jsonl(
 ) -> None:
     """Append the entry as a single line. Rotate to `path.1` when over the threshold."""
     try:
-        _ensure_private_dir(path.parent)
+        ensure_private_dir(path.parent)
         if path.exists() and path.stat().st_size > rotate_bytes:
             rolled = path.with_suffix(path.suffix + ".1")
             os.replace(path, rolled)

--- a/tests/config/test_settings_private_dir.py
+++ b/tests/config/test_settings_private_dir.py
@@ -1,0 +1,52 @@
+"""`ensure_private_dir` hardens the nsc state-root chain to 0700 (issue #90).
+
+The `~/.nsc` root must be owner-only, not just its leaf dirs/files: it can
+hold cache, logs, and config side by side, so a world/group-readable root
+leaks directory listings on shared hosts.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+from nsc.config.settings import ensure_private_dir
+
+
+def test_creates_leaf_and_clamps_it_to_0700(tmp_path: Path) -> None:
+    leaf = tmp_path / "root" / "logs"
+    ensure_private_dir(leaf)
+    assert leaf.is_dir()
+    assert stat.S_IMODE(leaf.stat().st_mode) == 0o700
+
+
+def test_clamps_newly_created_intermediate_root_to_0700(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    leaf = root / "logs"
+    ensure_private_dir(leaf)
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+
+
+def test_tightens_preexisting_world_readable_leaf(tmp_path: Path) -> None:
+    leaf = tmp_path / "root" / "logs"
+    leaf.mkdir(parents=True)
+    leaf.chmod(0o755)
+    ensure_private_dir(leaf)
+    assert stat.S_IMODE(leaf.stat().st_mode) == 0o700
+
+
+def test_leaves_preexisting_restrictive_leaf_alone(tmp_path: Path) -> None:
+    leaf = tmp_path / "root" / "logs"
+    leaf.mkdir(parents=True)
+    leaf.chmod(0o500)
+    ensure_private_dir(leaf)
+    assert stat.S_IMODE(leaf.stat().st_mode) == 0o500
+
+
+def test_does_not_touch_preexisting_ancestor_mode(tmp_path: Path) -> None:
+    """An ancestor that already existed (e.g. $HOME) keeps its mode untouched."""
+    root = tmp_path / "root"
+    root.mkdir()
+    root.chmod(0o755)
+    ensure_private_dir(root / "logs")
+    assert stat.S_IMODE(root.stat().st_mode) == 0o755

--- a/tests/config/test_writer_atomicity.py
+++ b/tests/config/test_writer_atomicity.py
@@ -19,6 +19,13 @@ def test_atomic_write_creates_file_with_0600_permissions(tmp_path: Path) -> None
     assert mode == 0o600
 
 
+def test_atomic_write_clamps_created_parent_dir_to_0700(tmp_path: Path) -> None:
+    """The `~/.nsc` root created as a side effect of the first write is owner-only."""
+    root = tmp_path / ".nsc"
+    atomic_write(root / "config.yaml", "hello: world\n")
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+
+
 def test_atomic_write_replaces_existing_file_atomically(tmp_path: Path) -> None:
     target = tmp_path / "config.yaml"
     target.write_text("old: value\n", encoding="utf-8")

--- a/tests/http/test_audit_permissions.py
+++ b/tests/http/test_audit_permissions.py
@@ -64,6 +64,13 @@ def test_append_tightens_preexisting_world_readable_dir(tmp_path: Path) -> None:
     assert stat.S_IMODE(log_dir.stat().st_mode) == 0o700
 
 
+def test_append_clamps_created_state_root_to_0700(tmp_path: Path) -> None:
+    """The `~/.nsc` root created as a side effect of writing `logs/` is owner-only."""
+    root = tmp_path / ".nsc"
+    append_audit_jsonl(_entry(), path=root / "logs" / "audit.jsonl")
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+
+
 def test_file_created_0600_by_open_mode_not_just_chmod(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #90

## Summary

The `~/.nsc` **root** directory was created with default umask perms (~0755) — by `nsc/config/writer.py` (`atomic_write` / `acquire_lock` via plain `mkdir`) and as a side effect of audit-dir creation in `nsc/http/audit.py`. The leaves were already hardened (`config.yaml` 0600, `audit.jsonl` 0600, `logs/` 0700), but the root chain was not, leaking state-tree directory listings on shared hosts.

This adds a single shared helper `ensure_private_dir(directory)` in `nsc/config/settings.py` — the layer that owns the state root (`Paths.root`) — that:

- creates `directory` with parents and clamps **every newly-created ancestor** (including an intermediate `~/.nsc`) to `0700`;
- tightens a pre-existing world/group-readable leaf to `0700` (preserving the existing audit behaviour for a `logs/` left 0755 by an older version);
- leaves an already-restrictive leaf and pre-existing ancestors (e.g. `$HOME`) untouched.

The config writer and both audit writers now route through it. Audit's old leaf-only `_ensure_private_dir` is removed in favour of the shared helper; mode constants mirror the existing `0600`/`0700` treatment.

No file contents change — directory mode only. Nothing already hardened is loosened.

## Tests

- New `tests/config/test_settings_private_dir.py`: leaf clamp, intermediate-root clamp, tighten-loose-leaf, leave-restrictive-leaf, don't-touch-preexisting-ancestor.
- `tests/config/test_writer_atomicity.py`: first config write clamps the created `~/.nsc` root to 0700.
- `tests/http/test_audit_permissions.py`: writing `logs/audit.jsonl` clamps the created `~/.nsc` root to 0700.

`just fix` + `just lint` (ruff check, ruff format --check, mypy --strict) clean; `just test` = 1086 passed, 1 skipped.

> Mode-bit asserts follow the existing POSIX-only convention already used across `tests/http/test_audit_permissions.py` and `tests/config/test_writer_atomicity.py` (no Windows guard in impl or tests, matching the prior `_ensure_private_dir` clamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)