### PR TITLE
feat: --workers N for concurrent bulk-loop fallback

### DIFF
--- a/nsc/cli/handlers.py
+++ b/nsc/cli/handlers.py
@@ -26,6 +26,7 @@ from nsc.cli.writes.confirmation import (
     refuse_all_on_writes,
     refuse_bulk_and_no_bulk_together,
     refuse_delete_without_id,
+    refuse_invalid_workers,
     refuse_unknown_on_error,
     refuse_unsupported_bulk,
 )
@@ -254,6 +255,7 @@ def _handle_write(
             operation_id=operation.operation_id,
         )
         refuse_unknown_on_error(ctx.on_error)
+        refuse_invalid_workers(ctx.workers)
 
         is_delete = operation.http_method is HttpMethod.DELETE
         if is_delete:
@@ -454,6 +456,7 @@ def _execute_loop(
         send_one=_send_one_loop,
         audit_attempt=_audit_one,
         to_envelope=_to_envelope,
+        workers=ctx.workers,
     )
 
     failures: list[ErrorEnvelope] = []

--- a/nsc/cli/registration.py
+++ b/nsc/cli/registration.py
@@ -205,6 +205,7 @@ def _build_write_closure(
         bulk: bool | None = kwargs.pop("bulk", None)
         no_bulk: bool | None = kwargs.pop("no_bulk", None)
         on_error: str = kwargs.pop("on_error", "stop")
+        workers: int = kwargs.pop("workers", 1)
         ctx = get_ctx()
         update: dict[str, Any] = {
             "compact": compact,
@@ -218,6 +219,7 @@ def _build_write_closure(
             "bulk": bulk,
             "no_bulk": no_bulk,
             "on_error": on_error,
+            "workers": workers,
         }
         if output:
             update["output_format"] = OutputFormat(output)
@@ -430,6 +432,19 @@ def _write_flag_params() -> list[inspect.Parameter]:
                 help=(
                     "stop|continue. stop: abort on first failure (default). "
                     "continue: attempt every record; final exit code = worst error type."
+                ),
+            ),
+        ),
+        inspect.Parameter(
+            name="workers",
+            kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=int,
+            default=typer.Option(
+                1,
+                "--workers",
+                help=(
+                    "Concurrent in-flight requests for the per-record loop (must be >= 1). "
+                    "1 (default) runs sequentially. Only affects looped (non-bulk) writes."
                 ),
             ),
         ),

--- a/nsc/cli/registration.py
+++ b/nsc/cli/registration.py
@@ -443,8 +443,11 @@ def _write_flag_params() -> list[inspect.Parameter]:
                 1,
                 "--workers",
                 help=(
-                    "Concurrent in-flight requests for the per-record loop (must be >= 1). "
-                    "1 (default) runs sequentially. Only affects looped (non-bulk) writes."
+                    "Concurrent in-flight requests for the per-record loop (1-32). "
+                    "1 (default) runs sequentially. Only affects looped (non-bulk) "
+                    "writes. With --on-error stop, concurrency only bounds *new* "
+                    "submissions: in-flight requests (up to --workers) still "
+                    "complete, so if record count <= workers all records are sent."
                 ),
             ),
         ),

--- a/nsc/cli/runtime.py
+++ b/nsc/cli/runtime.py
@@ -217,6 +217,7 @@ class RuntimeContext(BaseModel):
     bulk: bool | None = None
     no_bulk: bool | None = None
     on_error: Literal["stop", "continue"] = "stop"
+    workers: int = 1
 
     def resolve_columns(self, tag: str, resource: str, operation: Operation) -> list[str] | None:
         if self.columns_override is not None:

--- a/nsc/cli/writes/bulk.py
+++ b/nsc/cli/writes/bulk.py
@@ -198,10 +198,12 @@ def run_loop(
     a thread pool (the NetBox client is sync httpx, so threads — not asyncio —
     are the right mechanism). Each record's send/retry/audit is independent.
 
-    On `on_error="stop"` the loop stops submitting new work after the first
+    On `on_error="stop"` the loop stops submitting *new* work after the first
     failure; in-flight requests are allowed to complete (cancelling them would
     leave partially-applied writes whose outcome the audit log could not
-    record). On `"continue"` every request is attempted.
+    record). Because up to `workers` requests dispatch in the first wave,
+    `stop` cannot prevent any send when `len(requests) <= workers` — all of
+    them are already in flight. On `"continue"` every request is attempted.
 
     Audit fires once per attempted request (success and failure). Under
     concurrency the audit *callback* may run from worker threads; the injected

--- a/nsc/cli/writes/bulk.py
+++ b/nsc/cli/writes/bulk.py
@@ -12,7 +12,9 @@ Pure logic. No I/O, no Typer, no httpx. Three responsibilities:
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, assert_never
@@ -186,17 +188,60 @@ def run_loop(
     send_one: SendOne,
     audit_attempt: AuditAttempt,
     to_envelope: ToEnvelope,
+    workers: int = 1,
 ) -> LoopResult:
-    """Sequentially send N requests; collect successes and failures (spec §4.5).
+    """Send N requests; collect successes and failures (spec §4.5).
 
-    The loop never spawns concurrency. Audit fires once per attempted request
-    (success and failure). On `on_error="stop"` the loop aborts on the first
-    failure; on `"continue"` it attempts every request.
+    With `workers == 1` the loop is sequential and deterministic: requests run
+    in input order and audit fires once per attempted request in that order.
+    With `workers > 1` up to `workers` requests are in flight concurrently via
+    a thread pool (the NetBox client is sync httpx, so threads — not asyncio —
+    are the right mechanism). Each record's send/retry/audit is independent.
+
+    On `on_error="stop"` the loop stops submitting new work after the first
+    failure; in-flight requests are allowed to complete (cancelling them would
+    leave partially-applied writes whose outcome the audit log could not
+    record). On `"continue"` every request is attempted.
+
+    Audit fires once per attempted request (success and failure). Under
+    concurrency the audit *callback* may run from worker threads; the injected
+    writer must be thread-safe (the production audit writer serializes appends).
 
     `send_one` does the wire send; `audit_attempt` writes the audit entry;
     `to_envelope` converts a raised exception into an ErrorEnvelope. Callers
     inject these so this loop has no dependency on httpx or the audit module.
     """
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1, got {workers}")
+    if workers == 1:
+        return _run_loop_sequential(
+            requests,
+            operation=operation,
+            on_error=on_error,
+            send_one=send_one,
+            audit_attempt=audit_attempt,
+            to_envelope=to_envelope,
+        )
+    return _run_loop_concurrent(
+        requests,
+        operation=operation,
+        on_error=on_error,
+        send_one=send_one,
+        audit_attempt=audit_attempt,
+        to_envelope=to_envelope,
+        workers=workers,
+    )
+
+
+def _run_loop_sequential(
+    requests: list[ResolvedRequest],
+    *,
+    operation: Operation,
+    on_error: Literal["stop", "continue"],
+    send_one: SendOne,
+    audit_attempt: AuditAttempt,
+    to_envelope: ToEnvelope,
+) -> LoopResult:
     attempts: list[LoopAttempt] = []
     for request in requests:
         try:
@@ -212,6 +257,67 @@ def run_loop(
         else:
             audit_attempt(request, response, None)
             attempts.append(LoopAttempt(request=request, response=response, failure=None))
+    return LoopResult(attempts=attempts)
+
+
+def _attempt_one(
+    request: ResolvedRequest,
+    *,
+    operation: Operation,
+    send_one: SendOne,
+    audit_attempt: AuditAttempt,
+    to_envelope: ToEnvelope,
+) -> LoopAttempt:
+    try:
+        response = send_one(operation, request)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception as exc:
+        audit_attempt(request, None, exc)
+        return LoopAttempt(request=request, response=None, failure=to_envelope(exc))
+    audit_attempt(request, response, None)
+    return LoopAttempt(request=request, response=response, failure=None)
+
+
+def _run_loop_concurrent(
+    requests: list[ResolvedRequest],
+    *,
+    operation: Operation,
+    on_error: Literal["stop", "continue"],
+    send_one: SendOne,
+    audit_attempt: AuditAttempt,
+    to_envelope: ToEnvelope,
+    workers: int,
+) -> LoopResult:
+    pending = iter(requests)
+    stop = threading.Event()
+
+    def run(request: ResolvedRequest) -> LoopAttempt:
+        return _attempt_one(
+            request,
+            operation=operation,
+            send_one=send_one,
+            audit_attempt=audit_attempt,
+            to_envelope=to_envelope,
+        )
+
+    attempts: list[LoopAttempt] = []
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        in_flight: set[Future[LoopAttempt]] = set()
+        for request in pending:
+            in_flight.add(pool.submit(run, request))
+            if len(in_flight) < workers:
+                continue
+            done, in_flight = wait(in_flight, return_when=FIRST_COMPLETED)
+            for future in done:
+                attempt = future.result()
+                attempts.append(attempt)
+                if attempt.failure is not None and on_error == "stop":
+                    stop.set()
+            if stop.is_set():
+                break
+        for future in in_flight:
+            attempts.append(future.result())
     return LoopResult(attempts=attempts)
 
 

--- a/nsc/cli/writes/confirmation.py
+++ b/nsc/cli/writes/confirmation.py
@@ -74,6 +74,18 @@ def refuse_unsupported_bulk(err: UnsupportedBulkError, *, operation_id: str) -> 
     )
 
 
+def refuse_invalid_workers(value: int) -> None:
+    if value >= 1:
+        return
+    raise ClientError(
+        client_envelope(
+            f"--workers must be >= 1, got {value}",
+            flag="--workers",
+            value=str(value),
+        )
+    )
+
+
 def refuse_unknown_on_error(value: str) -> None:
     if value in _SUPPORTED_ON_ERROR:
         return
@@ -90,6 +102,7 @@ __all__ = [
     "refuse_all_on_writes",
     "refuse_bulk_and_no_bulk_together",
     "refuse_delete_without_id",
+    "refuse_invalid_workers",
     "refuse_unknown_format_for_writes",
     "refuse_unknown_on_error",
     "refuse_unsupported_bulk",

--- a/nsc/cli/writes/confirmation.py
+++ b/nsc/cli/writes/confirmation.py
@@ -74,16 +74,26 @@ def refuse_unsupported_bulk(err: UnsupportedBulkError, *, operation_id: str) -> 
     )
 
 
+MAX_WORKERS = 32
+
+
 def refuse_invalid_workers(value: int) -> None:
-    if value >= 1:
-        return
-    raise ClientError(
-        client_envelope(
-            f"--workers must be >= 1, got {value}",
-            flag="--workers",
-            value=str(value),
+    if value < 1:
+        raise ClientError(
+            client_envelope(
+                f"--workers must be >= 1, got {value}",
+                flag="--workers",
+                value=str(value),
+            )
         )
-    )
+    if value > MAX_WORKERS:
+        raise ClientError(
+            client_envelope(
+                f"--workers must be <= {MAX_WORKERS}, got {value}",
+                flag="--workers",
+                value=str(value),
+            )
+        )
 
 
 def refuse_unknown_on_error(value: str) -> None:
@@ -99,6 +109,7 @@ def refuse_unknown_on_error(value: str) -> None:
 
 
 __all__ = [
+    "MAX_WORKERS",
     "refuse_all_on_writes",
     "refuse_bulk_and_no_bulk_together",
     "refuse_delete_without_id",

--- a/nsc/http/audit.py
+++ b/nsc/http/audit.py
@@ -16,6 +16,7 @@ import os
 import stat
 import sys
 import tempfile
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,12 @@ SCHEMA_VERSION = 1
 # mirroring the 0600 treatment of config.yaml in nsc/config/writer.py.
 _DIR_MODE = 0o700
 _FILE_MODE = 0o600
+
+# Serializes audit appends across threads. The bulk loop can run with N
+# concurrent workers; buffered writes plus O_APPEND give no cross-thread
+# atomicity for lines larger than PIPE_BUF, so we take this lock around the
+# whole open/write/close to guarantee exactly one complete line per record.
+_APPEND_LOCK = threading.Lock()
 
 
 class _Frozen(BaseModel):
@@ -190,21 +197,27 @@ def append_audit_jsonl(
     path: Path,
     rotate_bytes: int = DEFAULT_ROTATE_BYTES,
 ) -> None:
-    """Append the entry as a single line. Rotate to `path.1` when over the threshold."""
-    try:
-        _ensure_private_dir(path.parent)
-        if path.exists() and path.stat().st_size > rotate_bytes:
-            rolled = path.with_suffix(path.suffix + ".1")
-            os.replace(path, rolled)
-            # os.replace keeps the source mode; force 0600 so a pre-existing
-            # world-readable log does not carry that mode onto the rotated copy.
-            os.chmod(rolled, _FILE_MODE)
-        # os.open with _FILE_MODE sets owner-only perms at creation (umask can
-        # only clear bits, never widen 0600); chmod fixes any pre-existing file.
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
-        with os.fdopen(fd, "a", encoding="utf-8") as fh:
-            os.chmod(path, _FILE_MODE)
-            fh.write(json.dumps(_to_dict(entry)))
-            fh.write("\n")
-    except OSError as exc:
-        _warn(f"could not append audit log {path}: {exc}")
+    """Append the entry as a single line. Rotate to `path.1` when over the threshold.
+
+    Thread-safe: the entire rotate/open/write/close runs under `_APPEND_LOCK`
+    so concurrent bulk-loop workers cannot interleave partial lines or race the
+    rotation check.
+    """
+    line = json.dumps(_to_dict(entry)) + "\n"
+    with _APPEND_LOCK:
+        try:
+            _ensure_private_dir(path.parent)
+            if path.exists() and path.stat().st_size > rotate_bytes:
+                rolled = path.with_suffix(path.suffix + ".1")
+                os.replace(path, rolled)
+                # os.replace keeps the source mode; force 0600 so a pre-existing
+                # world-readable log does not carry that mode onto the rotated copy.
+                os.chmod(rolled, _FILE_MODE)
+            # os.open with _FILE_MODE sets owner-only perms at creation (umask can
+            # only clear bits, never widen 0600); chmod fixes any pre-existing file.
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
+            with os.fdopen(fd, "a", encoding="utf-8") as fh:
+                os.chmod(path, _FILE_MODE)
+                fh.write(line)
+        except OSError as exc:
+            _warn(f"could not append audit log {path}: {exc}")

--- a/nsc/output/errors.py
+++ b/nsc/output/errors.py
@@ -279,8 +279,13 @@ def summary_envelope(
     Returns:
         ErrorEnvelope whose `type` equals the worst failure type by
         precedence, with `details.partial_progress = {success, failed, remaining}`.
-        On "stop" sets `record_index` to the first failure's index. On "continue"
+        On "stop" sets `record_index` to the lowest failing index. On "continue"
         adds `details.failures: [{record_index, type, status_code, error}, ...]`.
+
+    Determinism: under `--workers > 1` the caller's `failures` list arrives in
+    completion order, which varies run-to-run. The surfaced "first failure"
+    (stop mode) is therefore chosen by lowest `record_index`, not list position,
+    so two identical runs report the same `record_index`/`error`/`status_code`.
     """
     if not failures:
         raise ValueError("summary_envelope requires at least one failure")
@@ -300,7 +305,10 @@ def summary_envelope(
     }
 
     if on_error == "stop":
-        first = failures[0]
+        first = min(
+            failures,
+            key=lambda f: f.record_index if f.record_index is not None else -1,
+        )
         return ErrorEnvelope(
             error=first.error,
             type=chosen_type,

--- a/tests/cli/test_writes_respx.py
+++ b/tests/cli/test_writes_respx.py
@@ -595,3 +595,116 @@ def test_dry_run_bulk_writes_one_audit_entry(
     entry = json.loads(lines[0])
     assert entry["dry_run"] is True
     assert entry["record_indices"] == [0, 1, 2]
+
+
+# Issue #3: concurrent per-record loop (--workers N).
+
+
+@respx.mock
+def test_workers_below_one_returns_client_error(tmp_path: Path) -> None:
+    _mock_schema(respx.mock)
+    payload = _payload(tmp_path, _bulk_records(3))
+    result = CliRunner().invoke(
+        app,
+        [
+            "dcim",
+            "devices",
+            "create",
+            "-f",
+            str(payload),
+            "--apply",
+            "--no-bulk",
+            "--workers",
+            "0",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == EXIT_CODES[ErrorType.CLIENT]
+    parsed = json.loads(result.stdout)
+    assert parsed["type"] == "client"
+    assert parsed["details"]["flag"] == "--workers"
+
+
+@respx.mock
+def test_workers_loop_sends_every_record_and_audits_well_formed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fixture_profile_yaml: Path,
+) -> None:
+    home = _audit_home(tmp_path, monkeypatch, fixture_profile_yaml)
+    _mock_schema(respx.mock)
+    route = respx.post("https://nb.example/api/dcim/devices/").mock(
+        return_value=httpx.Response(201, json={"id": 1})
+    )
+    payload = _payload(tmp_path, _bulk_records(20))
+    result = CliRunner().invoke(
+        app,
+        [
+            "dcim",
+            "devices",
+            "create",
+            "-f",
+            str(payload),
+            "--apply",
+            "--no-bulk",
+            "--workers",
+            "8",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert route.call_count == 20
+    lines = (home / "logs" / "audit.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 20
+    # Every line is complete, well-formed JSON; exactly one record_index each.
+    indices: set[int] = set()
+    for line in lines:
+        entry = json.loads(line)
+        assert len(entry["record_indices"]) == 1
+        indices.add(entry["record_indices"][0])
+    assert indices == set(range(20))
+
+
+@respx.mock
+def test_workers_continue_attempts_every_record_under_concurrency(tmp_path: Path) -> None:
+    _mock_schema(respx.mock)
+    bad = {3, 7}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        idx = json.loads(request.content)["name"].split("-")[1]
+        if int(idx) in bad:
+            return httpx.Response(400, json={"name": ["bad"]})
+        return httpx.Response(201, json={"id": 1})
+
+    respx.post("https://nb.example/api/dcim/devices/").mock(side_effect=responder)
+    payload = _payload(tmp_path, _bulk_records(10))
+    result = CliRunner().invoke(
+        app,
+        [
+            "dcim",
+            "devices",
+            "create",
+            "-f",
+            str(payload),
+            "--apply",
+            "--no-bulk",
+            "--on-error",
+            "continue",
+            "--workers",
+            "4",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == EXIT_CODES[ErrorType.VALIDATION]
+    parsed = json.loads(result.stdout)
+    assert parsed["details"]["on_error"] == "continue"
+    assert parsed["details"]["partial_progress"] == {
+        "success": 8,
+        "failed": 2,
+        "remaining": 0,
+    }
+    indices = sorted(f["record_index"] for f in parsed["details"]["failures"])
+    assert indices == [3, 7]

--- a/tests/cli/test_writes_respx.py
+++ b/tests/cli/test_writes_respx.py
@@ -708,3 +708,86 @@ def test_workers_continue_attempts_every_record_under_concurrency(tmp_path: Path
     }
     indices = sorted(f["record_index"] for f in parsed["details"]["failures"])
     assert indices == [3, 7]
+
+
+@respx.mock
+def test_workers_above_cap_returns_client_error(tmp_path: Path) -> None:
+    _mock_schema(respx.mock)
+    payload = _payload(tmp_path, _bulk_records(3))
+    result = CliRunner().invoke(
+        app,
+        [
+            "dcim",
+            "devices",
+            "create",
+            "-f",
+            str(payload),
+            "--apply",
+            "--no-bulk",
+            "--workers",
+            "100000",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == EXIT_CODES[ErrorType.CLIENT]
+    parsed = json.loads(result.stdout)
+    assert parsed["type"] == "client"
+    assert parsed["details"]["flag"] == "--workers"
+    assert "<= 32" in parsed["error"]
+
+
+def _run_stop_under_concurrency(tmp_path: Path) -> dict[str, Any]:
+    """Run --workers 4 --on-error stop over 12 records where records 5 and 9
+    fail (400). Returns the parsed top-level error envelope."""
+    bad = {5, 9}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        idx = int(json.loads(request.content)["name"].split("-")[1])
+        if idx in bad:
+            return httpx.Response(400, json={"name": ["bad"]})
+        return httpx.Response(201, json={"id": idx})
+
+    respx.post("https://nb.example/api/dcim/devices/").mock(side_effect=responder)
+    payload = _payload(tmp_path, _bulk_records(12))
+    result = CliRunner().invoke(
+        app,
+        [
+            "dcim",
+            "devices",
+            "create",
+            "-f",
+            str(payload),
+            "--apply",
+            "--no-bulk",
+            "--on-error",
+            "stop",
+            "--workers",
+            "4",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == EXIT_CODES[ErrorType.VALIDATION], (
+        result.stdout,
+        result.stderr,
+    )
+    return json.loads(result.stdout)  # type: ignore[no-any-return]
+
+
+@respx.mock
+def test_workers_stop_surfaces_lowest_index_failure_deterministically(
+    tmp_path: Path,
+) -> None:
+    # The surfaced top-level failure under concurrency must be the LOWEST
+    # failing record_index, stable across repeated runs (not completion order).
+    seen: set[int] = set()
+    for _ in range(8):
+        respx.reset()
+        _mock_schema(respx.mock)
+        parsed = _run_stop_under_concurrency(tmp_path)
+        assert parsed["type"] == "validation"
+        assert parsed["details"]["on_error"] == "stop"
+        seen.add(parsed["record_index"])
+    # record 5 is the lowest failing index; it must win every single run.
+    assert seen == {5}

--- a/tests/cli/writes/test_bulk.py
+++ b/tests/cli/writes/test_bulk.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from collections.abc import Callable
 from typing import Literal
 
@@ -283,6 +285,139 @@ def test_run_loop_continue_attempts_every_record() -> None:
     # All five attempts audited (3 successes, 2 failures).
     assert [a[0] for a in audited] == [0, 1, 2, 3, 4]
     assert [a[1] for a in audited] == [False, True, False, True, True]
+
+
+def test_run_loop_rejects_workers_below_one() -> None:
+    with pytest.raises(ValueError, match=r"workers must be >= 1"):
+        run_loop(
+            [_req(0)],
+            operation=None,  # type: ignore[arg-type]
+            on_error="continue",
+            send_one=_ok,
+            audit_attempt=lambda *_a: None,
+            to_envelope=_to_envelope,
+            workers=0,
+        )
+
+
+def test_run_loop_workers_one_is_sequential_in_order() -> None:
+    audited: list[tuple[int, bool]] = []
+
+    def audit(req: ResolvedRequest, _resp: dict | None, err: Exception | None) -> None:
+        audited.append((req.record_indices[0], err is None))
+
+    result = run_loop(
+        [_req(i) for i in range(4)],
+        operation=None,  # type: ignore[arg-type]
+        on_error="continue",
+        send_one=_ok,
+        audit_attempt=audit,
+        to_envelope=_to_envelope,
+        workers=1,
+    )
+    assert result.attempted == 4
+    assert result.successes == 4
+    # workers=1 preserves input order exactly (byte-for-byte sequential).
+    assert [a[0] for a in audited] == [0, 1, 2, 3]
+    assert [a.request.record_indices[0] for a in result.attempts] == [0, 1, 2, 3]
+
+
+def test_run_loop_concurrent_continue_attempts_every_record() -> None:
+    audited: list[tuple[int, bool]] = []
+    lock = threading.Lock()
+
+    def audit(req: ResolvedRequest, _resp: dict | None, err: Exception | None) -> None:
+        with lock:
+            audited.append((req.record_indices[0], err is None))
+
+    def mixed(_op: object, request: ResolvedRequest) -> dict[str, object]:
+        idx = request.record_indices[0]
+        if idx in (3, 7):
+            raise _SimulatedFailure(
+                ErrorEnvelope(
+                    error="bad",
+                    type=ErrorType.VALIDATION,
+                    status_code=400,
+                    record_index=idx,
+                    operation_id="x_create",
+                )
+            )
+        return {"id": idx}
+
+    result = run_loop(
+        [_req(i) for i in range(10)],
+        operation=None,  # type: ignore[arg-type]
+        on_error="continue",
+        send_one=mixed,
+        audit_attempt=audit,
+        to_envelope=_to_envelope,
+        workers=4,
+    )
+    assert result.attempted == 10
+    assert result.successes == 8
+    # Order is not guaranteed under concurrency; compare as sets.
+    assert {f.record_index for f in result.failures} == {3, 7}
+    assert {a[0] for a in audited} == set(range(10))
+
+
+def test_run_loop_concurrent_is_faster_than_sequential() -> None:
+    def slow(_op: object, _request: ResolvedRequest) -> dict[str, object]:
+        time.sleep(0.05)
+        return {"id": 1}
+
+    requests = [_req(i) for i in range(8)]
+
+    start = time.monotonic()
+    run_loop(
+        requests,
+        operation=None,  # type: ignore[arg-type]
+        on_error="continue",
+        send_one=slow,
+        audit_attempt=lambda *_a: None,
+        to_envelope=_to_envelope,
+        workers=8,
+    )
+    concurrent_elapsed = time.monotonic() - start
+
+    # 8 records * 50ms sequential = 400ms; with 8 workers it should be ~50ms.
+    assert concurrent_elapsed < 0.20
+
+
+def test_run_loop_concurrent_stop_halts_submission_after_failure() -> None:
+    sent: list[int] = []
+    lock = threading.Lock()
+
+    def send(_op: object, request: ResolvedRequest) -> dict[str, object]:
+        idx = request.record_indices[0]
+        with lock:
+            sent.append(idx)
+        if idx == 0:
+            raise _SimulatedFailure(
+                ErrorEnvelope(
+                    error="bad",
+                    type=ErrorType.VALIDATION,
+                    status_code=400,
+                    record_index=0,
+                    operation_id="x_create",
+                )
+            )
+        time.sleep(0.02)
+        return {"id": idx}
+
+    result = run_loop(
+        [_req(i) for i in range(100)],
+        operation=None,  # type: ignore[arg-type]
+        on_error="stop",
+        send_one=send,
+        audit_attempt=lambda *_a: None,
+        to_envelope=_to_envelope,
+        workers=2,
+    )
+    # On stop, the first failure halts new submission; in-flight tasks finish.
+    # We must not have dispatched all 100 records.
+    assert len(sent) < 100
+    assert any(f.record_index == 0 for f in result.failures)
+    assert result.attempted == len(result.attempts)
 
 
 def test_loop_attempt_records_carry_response_or_envelope() -> None:

--- a/tests/http/test_audit.py
+++ b/tests/http/test_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -109,6 +110,28 @@ def test_append_audit_jsonl_writes_one_line_per_call(tmp_path: Path) -> None:
     assert len(lines) == 2
     assert json.loads(lines[0])["operation_id"] == "a"
     assert json.loads(lines[1])["operation_id"] == "b"
+
+
+def test_append_audit_jsonl_concurrent_appends_are_well_formed(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "audit.jsonl"
+    n = 200
+    # Large body so each serialized line far exceeds PIPE_BUF, defeating any
+    # reliance on a single-syscall append being atomic.
+    big = {"blob": "z" * 16384}
+
+    def write(i: int) -> None:
+        append_audit_jsonl(_entry(operation_id=f"op-{i}", request_body=big), path=target)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(write, range(n)))
+
+    lines = target.read_text().splitlines()
+    assert len(lines) == n
+    ops = set()
+    for line in lines:
+        parsed = json.loads(line)
+        ops.add(parsed["operation_id"])
+    assert ops == {f"op-{i}" for i in range(n)}
 
 
 def test_append_audit_jsonl_rotates_at_size_threshold(tmp_path: Path) -> None:

--- a/tests/output/test_errors.py
+++ b/tests/output/test_errors.py
@@ -206,6 +206,36 @@ def test_summary_envelope_stop_shape() -> None:
     assert env.details["on_error"] == "stop"
 
 
+def test_summary_envelope_stop_picks_lowest_index_regardless_of_order() -> None:
+    # Under --workers > 1 the failures list arrives in completion order, which
+    # is non-deterministic. The surfaced "first failure" must be the lowest
+    # record_index, independent of list position.
+    low = ErrorEnvelope(
+        error="low failed",
+        type=ErrorType.VALIDATION,
+        status_code=400,
+        record_index=2,
+        operation_id="x_create",
+    )
+    high = ErrorEnvelope(
+        error="high failed",
+        type=ErrorType.VALIDATION,
+        status_code=400,
+        record_index=7,
+        operation_id="x_create",
+    )
+    # high first in the list (as if it completed first under concurrency).
+    env = summary_envelope(
+        attempted=8,
+        failures=[high, low],
+        on_error="stop",
+        operation_id="x_create",
+        total_records=10,
+    )
+    assert env.record_index == 2
+    assert env.error == "low failed"
+
+
 def test_summary_envelope_raises_on_empty_failures() -> None:
     with pytest.raises(ValueError, match=r"summary_envelope requires at least one failure"):
         summary_envelope(


### PR DESCRIPTION
Closes #3

## What

Adds `--workers N` to per-record write loops (`create`/`update`/`delete` with
multiple records routed to the loop, e.g. `--no-bulk` or non-bulk-capable
endpoints). N requests run in flight concurrently.

```
nsc dcim devices create --ndjson devices.ndjson --apply --no-bulk --workers 8
```

## How

- **Concurrency mechanism: `concurrent.futures.ThreadPoolExecutor`.** The NetBox
  client is **sync httpx**, so threads (not asyncio) are the correct tool — each
  worker drives a blocking request through the shared client.
- `run_loop` gains `workers: int = 1`. `workers=1` dispatches to the unchanged
  sequential path (byte-for-byte identical, in input order). `workers>1` keeps up
  to N futures in flight, draining with `wait(FIRST_COMPLETED)`.
- **Audit thread-safety:** `append_audit_jsonl` now serializes the whole
  rotate/open/write/close under a module-level `threading.Lock`, and writes the
  full `json + "\n"` in a single `fh.write`. `O_APPEND` alone is *not* atomic for
  lines over `PIPE_BUF` with buffered IO, so the lock is the rigorous guarantee:
  exactly one complete, well-formed JSON line per record, no interleaving.
- **on-error semantics preserved:** `continue` attempts every record; `stop`
  halts *new submission* on the first failure while letting in-flight requests
  complete (cancelling mid-write would leave outcomes the audit log can't record).
- **Validation:** `--workers < 1` is refused with a `client`-type error envelope
  (`flag: --workers`); `run_loop` also guards `workers >= 1` defensively.
- Counts/exit codes are computed order-independently, so summary + exit-code
  semantics stay correct under concurrency.

## Tests

- `tests/cli/writes/test_bulk.py`: workers validation, workers=1 stays
  sequential/in-order, concurrent `continue` attempts all records, concurrency is
  measurably faster than sequential, `stop` halts submission after a failure.
- `tests/http/test_audit.py`: 200 concurrent appends with 16KB bodies (well over
  PIPE_BUF) across 16 threads → 200 well-formed lines, no corruption. (This test
  fails without the lock.)
- `tests/cli/test_writes_respx.py`: end-to-end `--workers` — `--workers 0`
  refused, 20-record loop sends all 20 and writes 20 well-formed audit lines,
  concurrent `--on-error continue` reports both failures.

`just fix` / `just lint` (ruff + mypy --strict) clean. Full suite: 1088 passed,
1 skipped.

## Reviewer attention

- **Audit interleaving** — the central claim is the lock makes `append_audit_jsonl`
  safe under N threads. Confirm the lock spans the rotation check too (it does), so
  rotation can't race a concurrent append.
- **on-error stop** — under concurrency "stop" means *stop submitting*, not *cancel
  in-flight*. For N <= workers all records are dispatched in the first wave, so stop
  cannot prevent any send (documented in the `run_loop` docstring). Verify that's
  the intended contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)