### PR TITLE
ci: bump actions to Node 24 majors (checkout v5, setup-uv v7, deploy-pages v5)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,8 +10,8 @@ jobs:
   startup-time:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - name: Install
         run: uv sync --all-extras --dev
       - name: Benchmark

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Python
@@ -52,4 +52,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - name: Sync deps
         run: uv sync --frozen
       - name: Start NetBox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Python
@@ -28,9 +28,9 @@ jobs:
   docs-reference-fresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Python
@@ -43,9 +43,9 @@ jobs:
   agents-md-fresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     # prerequisites).
     steps:
       - name: Checkout (full history for changelog notes)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
           # main. Tags pushed from a topic branch (or any unmerged commit)
           # would otherwise publish from un-reviewed code. This guard rejects
           # any tag whose commit is not reachable from origin/main.
-          # actions/checkout@v4 with fetch-depth: 0 fetches the tag's full
+          # actions/checkout@v5 with fetch-depth: 0 fetches the tag's full
           # history but does not populate origin/main as a ref locally; we
           # fetch it explicitly here.
           git fetch origin main
@@ -62,7 +62,7 @@ jobs:
           echo "Tag $GITHUB_REF_NAME ($GITHUB_SHA) is on main."
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Python


### PR DESCRIPTION
Closes #9

GitHub is removing the Node 20 action runtime (every run currently emits a Node 20 deprecation annotation; deadline 2026-09-16). This bumps every Node-20 action pin to its latest major that ships Node 24 binaries.

## Version bumps (old -> new)

| Action | Old | New | Node | Workflows |
|---|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | node24 | bench, claude, docs, e2e, lint, release, test |
| `astral-sh/setup-uv` | `@v3` / `@v4` | `@v7` | node24 | bench, docs, e2e, lint, release, test |
| `actions/deploy-pages` | `@v4` | `@v5` | node24 | docs |

`setup-uv` was on `@v3` everywhere except `bench.yml` (`@v4`); both are unified to `@v7`. The latest release is `v8.2.0`, but `setup-uv` has not published a floating `v8` major tag yet (only `v8.0.0/v8.1.0/v8.2.0`), so `@v7` is the newest major that preserves the floating major-tag style. `setup-uv@v6` is still Node 20; `@v7` is the first Node 24 major.

## Left unchanged (intentional)

- `actions/upload-pages-artifact@v3` — composite action, no Node binary, not affected by the Node 20 removal.
- `pypa/gh-action-pypi-publish@release/v1` — PyPA's official floating-tag recommendation; left as-is per maintainer guidance.

## Notes

- SHA-pinning is a **separate** concern tracked in #16 and is intentionally **not** done here; this PR keeps the floating major-tag style and only changes Node-20 -> Node-24 version tags.
- Only `.github/workflows/*.yml` changed (7 files); no source/version/changelog/test changes.
- `grep` confirms no remaining `actions/checkout@v4` or `astral-sh/setup-uv@v3` (or `@v4`, or `deploy-pages@v4`) pins.
- CI going green on this PR validates Node 24 compatibility across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)