### PR TITLE
feat: stricter audit-redaction mode `audit_redaction: full`

### DIFF
--- a/docs/guides/audit-log.md
+++ b/docs/guides/audit-log.md
@@ -46,8 +46,12 @@ contains exactly five keys:
 {"method":"POST","url":"https://nb/api/users/users/","status_code":201,"timestamp":"2026-06-25T12:00:00.000Z","profile":"prod"}
 ```
 
-Nothing else is written: no request body, no response body, no headers, and no
-query string — so no field can carry a secret into the log.
+Nothing else is written: no request body, no response body, and no headers. The
+one remaining string — `url` — is sanitized to scheme + host + path before it is
+logged: the **query string is dropped** (a debug-mode GET can encode a
+`private_key` or similar filter value there) and any **`user:pass@` userinfo is
+stripped** (a `https://user:pass@host` profile URL would otherwise carry basic-auth
+credentials). So no field can carry a secret into the log.
 
 ## Trade-offs
 

--- a/docs/guides/audit-log.md
+++ b/docs/guides/audit-log.md
@@ -1,0 +1,67 @@
+# Audit log
+
+Every write request and response is appended to `~/.nsc/logs/audit.jsonl` (one
+JSON object per line), including dry-runs (flagged so you can tell they were
+never sent). The file is created owner-only (`0600`) inside a `0700` directory,
+so a co-located user on a shared host cannot read your mutations.
+
+## Redaction modes
+
+The `audit_redaction` setting under `defaults` in `~/.nsc/config.yaml` chooses
+how much of each exchange is written:
+
+```yaml
+defaults:
+  audit_redaction: safe   # default; or: full
+```
+
+| Mode | What lands in `audit.jsonl` |
+| --- | --- |
+| `safe` (default) | Full request/response records, with known secrets masked to `<redacted>`. |
+| `full` | Routing metadata only — no body, header, or query content at all. |
+
+### `safe` — redact known secrets
+
+The default. The complete exchange is logged so you can debug what was sent and
+what NetBox returned, but sensitive values are masked **before write**:
+
+- A field is sensitive if its OpenAPI schema has `format: password` OR its name
+  (case-insensitive) is `password`, `secret`, `token`, `api_key`, `apikey`,
+  `private_key`, `passphrase`, or `client_secret`. Top-level and nested fields
+  are masked; arrays of objects are masked per-element.
+- Sensitive **headers** (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`,
+  `Proxy-Authorization`) are masked on both request and response.
+- **Not** masked: the endpoint URL, query string, non-sensitive headers, and
+  **response bodies** (NetBox's response is recorded as-is — if it echoes back a
+  secret, that is NetBox's bug). This is the residual exposure `full` closes.
+
+### `full` — routing metadata only
+
+For compliance-sensitive deployments. Every body is **omitted entirely** (not
+truncated), regardless of shape or size — small JSON, large JSON, error
+envelopes, and multipart payloads all collapse to nothing. Each audit line
+contains exactly five keys:
+
+```json
+{"method":"POST","url":"https://nb/api/users/users/","status_code":201,"timestamp":"2026-06-25T12:00:00.000Z","profile":"prod"}
+```
+
+Nothing else is written: no request body, no response body, no headers, and no
+query string — so no field can carry a secret into the log.
+
+## Trade-offs
+
+| | `safe` | `full` |
+| --- | --- | --- |
+| Debugging | Easy — you can see the payload and the server response. | Hard — you only know *that* a call happened, not its contents. |
+| Compliance | Good for the common case; response bodies are unredacted. | Strictest; no body data ever persisted. |
+| Reproducing a failed write | Possible from the recorded body. | Not possible from the log alone. |
+
+Switch to `full` when policy forbids persisting request/response payloads even
+in redacted form; otherwise keep the default `safe`, which preserves
+debuggability while masking known secrets.
+
+## Backward compatibility
+
+`safe` is the default and is unchanged. Existing configs — whether they set
+`audit_redaction: safe` or omit the key entirely — behave exactly as before.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -11,7 +11,7 @@ All fields below describe `~/.nsc/config.yaml`.
 |---|---|---|
 | `default_profile` | `str | None` | `None` |
 | `profiles` | `dict[str, Profile]` | `{}` |
-| `defaults` | `<class 'Defaults'>` | `Defaults(output=<OutputFormat.TABLE: 'table'>, page_size=50, timeout=30.0, schema_refresh=<SchemaRefresh.DAILY: 'daily'>, color_mode=<ColorMode.AUTO: 'auto'>)` |
+| `defaults` | `<class 'Defaults'>` | `Defaults(output=<OutputFormat.TABLE: 'table'>, page_size=50, timeout=30.0, schema_refresh=<SchemaRefresh.DAILY: 'daily'>, color_mode=<ColorMode.AUTO: 'auto'>, audit_redaction=<AuditRedaction.SAFE: 'safe'>)` |
 | `columns` | `dict[str, dict[str, list[str]]]` | `{}` |
 
 ## `Profile`
@@ -34,3 +34,4 @@ All fields below describe `~/.nsc/config.yaml`.
 | `timeout` | `<class 'float'>` | `30.0` |
 | `schema_refresh` | `<enum 'SchemaRefresh'>` | `<SchemaRefresh.DAILY: 'daily'>` |
 | `color_mode` | `<enum 'ColorMode'>` | `<ColorMode.AUTO: 'auto'>` |
+| `audit_redaction` | `<enum 'AuditRedaction'>` | `<AuditRedaction.SAFE: 'safe'>` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Working with plugins: guides/working-with-plugins.md
       - Output formats: guides/output-formats.md
       - Writes and safety: guides/writes-and-safety.md
+      - Audit log: guides/audit-log.md
       - CI and automation: guides/ci-and-automation.md
       - Using with AI agents: guides/using-with-ai-agents.md
   - Reference:

--- a/nsc/cli/globals.py
+++ b/nsc/cli/globals.py
@@ -42,7 +42,12 @@ def build_runtime_context(state: GlobalState) -> RuntimeContext:
         is_tty=sys.stdout.isatty(),
         default=state.config.defaults.output,
     )
-    client = NetBoxClient(profile, debug=state.debug)  # type: ignore[arg-type]
+    client = NetBoxClient(
+        profile,  # type: ignore[arg-type]
+        debug=state.debug,
+        redaction=state.config.defaults.audit_redaction,
+        profile_name=profile.name,
+    )
     return RuntimeContext(
         resolved_profile=profile,
         config=state.config,

--- a/nsc/cli/handlers.py
+++ b/nsc/cli/handlers.py
@@ -532,6 +532,8 @@ def _emit_dry_run_audit(
             record_indices=list(r.record_indices),
             applied=False,
             explain=ctx.explain,
+            profile=ctx.resolved_profile.name,
+            redaction=ctx.config.defaults.audit_redaction,
         )
         append_audit_jsonl(entry, path=log_dir / "audit.jsonl")
     _ = preflight  # currently consumed only via preflight_blocked

--- a/nsc/config/models.py
+++ b/nsc/config/models.py
@@ -37,12 +37,21 @@ class ColorMode(StrEnum):
     OFF = "off"
 
 
+class AuditRedaction(StrEnum):
+    # SAFE redacts only known secrets (passwords/tokens) in bodies; FULL omits
+    # every body, leaving routing metadata only — stricter compliance, harder
+    # debugging. SAFE is the default for backward compatibility.
+    SAFE = "safe"
+    FULL = "full"
+
+
 class Defaults(_Frozen):
     output: OutputFormat = OutputFormat.TABLE
     page_size: int = 50
     timeout: float = 30.0
     schema_refresh: SchemaRefresh = SchemaRefresh.DAILY
     color_mode: ColorMode = ColorMode.AUTO
+    audit_redaction: AuditRedaction = AuditRedaction.SAFE
 
 
 class Profile(_Frozen):

--- a/nsc/http/audit.py
+++ b/nsc/http/audit.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from nsc.config.models import AuditRedaction
 from nsc.config.settings import ensure_private_dir
 from nsc.model.command_model import HttpMethod
 from nsc.output.headers import SENSITIVE_HEADERS
@@ -66,6 +67,8 @@ class AuditEntry(_Frozen):
     record_indices: list[int] = Field(default_factory=list)
     applied: bool = False
     explain: bool = False
+    profile: str | None = None
+    redaction: AuditRedaction = AuditRedaction.SAFE
 
 
 def redact_headers(headers: dict[str, str]) -> dict[str, str]:
@@ -120,8 +123,26 @@ def truncate_body(body: Any, *, cap_bytes: int = DEFAULT_BODY_CAP_BYTES) -> tupl
     return {"_truncated": True, "_size_bytes": len(serialized)}, True
 
 
+def _to_dict_full(entry: AuditEntry) -> dict[str, Any]:
+    """`audit_redaction: full` line: routing metadata only, no body/header/query.
+
+    Compliance escalation — omitting bodies entirely (not truncating) removes
+    every channel a secret could ride on: request/response bodies, headers, and
+    query string. Only `status_code` is taken from the response object.
+    """
+    return {
+        "method": entry.method.value,
+        "url": entry.url,
+        "status_code": entry.response_status_code,
+        "timestamp": entry.timestamp,
+        "profile": entry.profile,
+    }
+
+
 def _to_dict(entry: AuditEntry) -> dict[str, Any]:
     """Serialize to the wire shape documented in spec §4.3."""
+    if entry.redaction is AuditRedaction.FULL:
+        return _to_dict_full(entry)
     req_body, req_trunc = truncate_body(redact_body(entry.request_body, entry.sensitive_paths))
     resp_body, resp_trunc = truncate_body(entry.response_body)
     return {

--- a/nsc/http/audit.py
+++ b/nsc/http/audit.py
@@ -19,6 +19,7 @@ import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -123,16 +124,41 @@ def truncate_body(body: Any, *, cap_bytes: int = DEFAULT_BODY_CAP_BYTES) -> tupl
     return {"_truncated": True, "_size_bytes": len(serialized)}, True
 
 
+def _sanitize_url(url: str) -> str:
+    """Reduce `url` to scheme + host[:port] + path, dropping query and userinfo.
+
+    The query string of a debug-mode GET can carry secret filter values
+    (e.g. `?private_key=...`), and `Profile.url` permits `https://user:pass@host`
+    whose `user:pass@` httpx keeps in `str(request.url)`. Both are stripped so a
+    `full` line cannot leak a credential through the one remaining string field.
+
+    Robust to URLs with no query/userinfo (no-op) and to relative/edge URLs: if
+    splitting yields no scheme and host, the original is returned unchanged
+    rather than producing a misleading empty value.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.scheme and not parts.hostname:
+        return url
+    host = parts.hostname or ""
+    netloc = f"{host}:{parts.port}" if parts.port is not None else host
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
 def _to_dict_full(entry: AuditEntry) -> dict[str, Any]:
     """`audit_redaction: full` line: routing metadata only, no body/header/query.
 
     Compliance escalation — omitting bodies entirely (not truncating) removes
     every channel a secret could ride on: request/response bodies, headers, and
-    query string. Only `status_code` is taken from the response object.
+    query string. The URL is sanitized to scheme + host + path (`_sanitize_url`)
+    so neither query params nor `user:pass@` userinfo leak. Only `status_code`
+    is taken from the response object.
     """
     return {
         "method": entry.method.value,
-        "url": entry.url,
+        "url": _sanitize_url(entry.url),
         "status_code": entry.response_status_code,
         "timestamp": entry.timestamp,
         "profile": entry.profile,

--- a/nsc/http/client.py
+++ b/nsc/http/client.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import httpx
 
+from nsc.config.models import AuditRedaction
 from nsc.config.settings import default_paths
 from nsc.http.audit import (
     AuditEntry,
@@ -41,11 +42,20 @@ class _ProfileLike(Protocol):
 
 
 class NetBoxClient:
-    def __init__(self, profile: _ProfileLike, *, debug: bool = False) -> None:
+    def __init__(
+        self,
+        profile: _ProfileLike,
+        *,
+        debug: bool = False,
+        redaction: AuditRedaction = AuditRedaction.SAFE,
+        profile_name: str | None = None,
+    ) -> None:
         if profile.token is None:
             raise ValueError("NetBoxClient requires a non-None token on the profile")
         self._url = str(profile.url).rstrip("/")
         self._debug = debug
+        self._redaction = redaction
+        self._profile_name = profile_name
         self._client = httpx.Client(
             base_url=self._url,
             headers={
@@ -327,6 +337,8 @@ class NetBoxClient:
             record_indices=list(record_indices),
             applied=is_write,
             explain=False,
+            profile=self._profile_name,
+            redaction=self._redaction,
         )
         log_dir = default_paths().logs_dir
         write_last_request(entry, path=log_dir / "last-request.json")

--- a/tests/audit/test_redaction_full.py
+++ b/tests/audit/test_redaction_full.py
@@ -138,3 +138,67 @@ def test_full_always_contains_each_allowed_key(tmp_path: Path, missing: str) -> 
     entry = _entry(request_body={"x": 1}, response_body={"y": 2})
     line = _emit(entry, tmp_path)
     assert missing in line
+
+
+def test_full_url_strips_query_and_credentials(tmp_path: Path) -> None:
+    """A debug-mode GET can carry filter params + basic-auth userinfo in the URL.
+
+    `full` mode must reduce the URL to scheme + host + path so neither the query
+    string (which may hold a `private_key` filter) nor the `user:pass@` userinfo
+    leaks into the audit line.
+    """
+    entry = AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        method=HttpMethod.GET,
+        url="https://user:pass@nb/api/x/?private_key=SECRETVAL&q=a",
+        request_body=None,
+        response_status_code=200,
+        profile="prod",
+        redaction=AuditRedaction.FULL,
+    )
+    line = _emit(entry, tmp_path)
+    assert set(line.keys()) == _ALLOWED_KEYS
+    assert line["url"] == "https://nb/api/x/"
+    blob = json.dumps(line)
+    for leak in ("SECRETVAL", "private_key", "pass", "user"):
+        assert leak not in blob
+
+
+def test_full_url_with_port_preserved(tmp_path: Path) -> None:
+    entry = AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        method=HttpMethod.GET,
+        url="https://nb:8443/api/x/?q=a",
+        request_body=None,
+        response_status_code=200,
+        profile="prod",
+        redaction=AuditRedaction.FULL,
+    )
+    line = _emit(entry, tmp_path)
+    assert line["url"] == "https://nb:8443/api/x/"
+
+
+def test_full_url_no_query_or_userinfo_is_noop(tmp_path: Path) -> None:
+    entry = AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        method=HttpMethod.GET,
+        url="https://nb/api/x/",
+        request_body=None,
+        response_status_code=200,
+        profile="prod",
+        redaction=AuditRedaction.FULL,
+    )
+    line = _emit(entry, tmp_path)
+    assert line["url"] == "https://nb/api/x/"
+
+
+def test_full_excludes_hypothetical_extra_entry_field(tmp_path: Path) -> None:
+    """Regression guard: `full` lines are an allow-list, not a deny-list.
+
+    If a new field is added to `AuditEntry`, it must not silently appear in a
+    `full` line. The emitted key set stays pinned to `_ALLOWED_KEYS`.
+    """
+    entry = _entry(request_body={"x": 1}, response_body={"y": 2})
+    line = _emit(entry, tmp_path)
+    extra = set(line.keys()) - _ALLOWED_KEYS
+    assert extra == set(), f"unexpected keys leaked into full line: {extra}"

--- a/tests/audit/test_redaction_full.py
+++ b/tests/audit/test_redaction_full.py
@@ -1,0 +1,140 @@
+"""Phase 6: `audit_redaction: full` — strip every body from audit lines.
+
+In `full` mode an audit line carries ONLY routing metadata
+(`{method, url, status_code, timestamp, profile}`) regardless of body shape
+or size. These tests assert no body/header/query content can leak.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nsc.config.models import AuditRedaction
+from nsc.http.audit import AuditEntry, append_audit_jsonl
+from nsc.model.command_model import HttpMethod
+
+_ALLOWED_KEYS = {"method", "url", "status_code", "timestamp", "profile"}
+
+
+def _entry(*, request_body: Any, response_body: Any) -> AuditEntry:
+    return AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        operation_id="users_users_create",
+        method=HttpMethod.POST,
+        url="https://nb/api/users/users/",
+        request_headers={"Authorization": "Token abc123"},
+        request_query={"q": "secret-search"},
+        request_body=request_body,
+        sensitive_paths=(),
+        response_status_code=201,
+        response_headers={"Set-Cookie": "sessionid=topsecret"},
+        response_body=response_body,
+        duration_ms=42,
+        profile="prod",
+        redaction=AuditRedaction.FULL,
+    )
+
+
+def _emit(entry: AuditEntry, tmp_path: Path) -> dict[str, Any]:
+    p = tmp_path / "audit.jsonl"
+    append_audit_jsonl(entry, path=p)
+    parsed: dict[str, Any] = json.loads(p.read_text().splitlines()[0])
+    return parsed
+
+
+def _assert_only_allowed(line: dict[str, Any]) -> None:
+    assert set(line.keys()) == _ALLOWED_KEYS
+    blob = json.dumps(line)
+    for leak in ("abc123", "secret-search", "topsecret", "password", "hunter2"):
+        assert leak not in blob
+
+
+def test_full_small_json_body(tmp_path: Path) -> None:
+    entry = _entry(
+        request_body={"username": "alice", "password": "hunter2"},
+        response_body={"id": 1, "username": "alice"},
+    )
+    line = _emit(entry, tmp_path)
+    _assert_only_allowed(line)
+    assert line == {
+        "method": "POST",
+        "url": "https://nb/api/users/users/",
+        "status_code": 201,
+        "timestamp": "2026-06-25T12:00:00.000Z",
+        "profile": "prod",
+    }
+
+
+def test_full_large_json_body(tmp_path: Path) -> None:
+    big = {"items": [{"i": i, "password": "hunter2"} for i in range(5000)]}
+    entry = _entry(request_body=big, response_body=big)
+    line = _emit(entry, tmp_path)
+    _assert_only_allowed(line)
+
+
+def test_full_error_envelope_body(tmp_path: Path) -> None:
+    envelope = {
+        "error": {
+            "kind": "validation",
+            "message": "token 'abc123' is invalid",
+            "details": {"password": ["hunter2 is too weak"]},
+        }
+    }
+    entry = _entry(request_body={"password": "hunter2"}, response_body=envelope)
+    line = _emit(entry, tmp_path)
+    _assert_only_allowed(line)
+
+
+def test_full_multipart_body(tmp_path: Path) -> None:
+    multipart = (
+        "--boundary\r\n"
+        'Content-Disposition: form-data; name="password"\r\n\r\n'
+        "hunter2\r\n"
+        "--boundary--\r\n"
+    )
+    entry = _entry(request_body=multipart, response_body="ok")
+    line = _emit(entry, tmp_path)
+    _assert_only_allowed(line)
+
+
+def test_full_omits_response_when_status_none(tmp_path: Path) -> None:
+    entry = AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        method=HttpMethod.DELETE,
+        url="https://nb/api/dcim/devices/1/",
+        request_body=None,
+        response_status_code=None,
+        profile="prod",
+        redaction=AuditRedaction.FULL,
+    )
+    line = _emit(entry, tmp_path)
+    assert set(line.keys()) == _ALLOWED_KEYS
+    assert line["status_code"] is None
+
+
+def test_safe_remains_default_and_keeps_body(tmp_path: Path) -> None:
+    entry = AuditEntry(
+        timestamp="2026-06-25T12:00:00.000Z",
+        method=HttpMethod.POST,
+        url="https://nb/api/users/users/",
+        request_body={"username": "alice", "password": "hunter2"},
+        sensitive_paths=("password",),
+        response_status_code=201,
+        response_body={"id": 1},
+        profile="prod",
+    )
+    assert entry.redaction is AuditRedaction.SAFE
+    line = _emit(entry, tmp_path)
+    assert line["request"]["body"] == {"username": "alice", "password": "<redacted>"}
+    assert "schema_version" in line
+
+
+@pytest.mark.parametrize("missing", sorted(_ALLOWED_KEYS))
+def test_full_always_contains_each_allowed_key(tmp_path: Path, missing: str) -> None:
+    entry = _entry(request_body={"x": 1}, response_body={"y": 2})
+    line = _emit(entry, tmp_path)
+    assert missing in line


### PR DESCRIPTION
Closes #5

## What

Adds a `full` audit-redaction mode for compliance-sensitive deployments, alongside the existing default `safe` mode.

In `full` mode every line in `~/.nsc/logs/audit.jsonl` contains **only** routing metadata — no body, header, or query content at all:

```json
{"method":"POST","url":"https://nb/api/users/users/","status_code":201,"timestamp":"2026-06-25T12:00:00.000Z","profile":"prod"}
```

Bodies are **omitted entirely** (not truncated), so shape/size is irrelevant and no field can carry a secret into the log. This also closes the residual `safe`-mode exposure where **response bodies are recorded unredacted**.

`safe` is unchanged and remains the default; configs that set `audit_redaction: safe` or omit the key behave exactly as before.

## How it's typed/wired

- New `AuditRedaction` `StrEnum` (`safe`/`full`) in `nsc/config/models.py`; `Defaults.audit_redaction: AuditRedaction = SAFE`.
- `AuditEntry` gains `profile: str | None` and `redaction: AuditRedaction = SAFE`. `_to_dict` branches to `_to_dict_full` when `full`.
- Threaded to the writer via `NetBoxClient(..., redaction=, profile_name=)` (real writes) and the dry-run emitter in `nsc/cli/handlers.py`.

## Files

- `nsc/config/models.py` — `AuditRedaction` enum + `Defaults.audit_redaction`
- `nsc/http/audit.py` — `AuditEntry.profile`/`.redaction`, `_to_dict_full`
- `nsc/http/client.py`, `nsc/cli/globals.py`, `nsc/cli/handlers.py` — thread config value through
- `tests/audit/test_redaction_full.py` — new (4 body shapes + leak/key assertions)
- `docs/guides/audit-log.md` — new page (modes + trade-offs); `mkdocs.yml` nav; `docs/reference/config.md` regenerated

## Verification

- `tests/audit/test_redaction_full.py`: 11 passed (small/large JSON, error-envelope, multipart; asserts exactly the 5 allowed keys and no secret leaks).
- Full suite: 1122 passed, 1 skipped.
- `ruff` clean, `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)