### PR TITLE
ci: declare explicit least-privilege permissions on all workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   startup-time:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,18 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Least-privilege default for the whole workflow; the single `claude` job
+# below re-declares the same scopes explicitly. The action only reads PRs
+# and issues here (no auto-commit/comment requested), so write scopes are
+# intentionally withheld — id-token: write is the sole write, required for
+# the action's OIDC handshake.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  id-token: write
+  actions: read # Required for Claude to read CI results on PRs
+
 jobs:
   claude:
     # Only trusted authors (repo owner/members/collaborators) can invoke the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Closes #12

Every workflow now declares an explicit top-level `permissions:` block, so none inherits the repo/org default token scope (GitHub least-privilege best practice).

## Per-workflow permissions

| Workflow | Top-level `permissions:` | Status |
|---|---|---|
| `bench.yml` | `contents: read` | **added** |
| `e2e.yml` | `contents: read` | **added** |
| `lint.yml` | `contents: read` | **added** |
| `test.yml` | `contents: read` | **added** |
| `claude.yml` | `contents: read`, `pull-requests: read`, `issues: read`, `id-token: write`, `actions: read` | **added** (top-level) |
| `docs.yml` | `contents: read`, `pages: write`, `id-token: write` | preserved |
| `release.yml` | `contents: write`, `id-token: write` | preserved |

## claude.yml scope rationale

`claude.yml` already declared these exact scopes at the **job** level but had no **top-level** block, so a future second job (or a workflow edit) would silently inherit the repo default. This PR lifts the same scopes to an explicit top-level block (the existing job-level block is retained as a redundant, explicit override).

Why each scope is needed:
- `id-token: write` — required for the `anthropics/claude-code-action@v1` OIDC handshake. Removing it breaks the action.
- `contents: read` — checkout + read repo.
- `pull-requests: read` / `issues: read` — the action reads PR/issue context to respond.
- `actions: read` — matches the `additional_permissions: actions: read` configured in the step (read CI results on PRs).

No **write** scopes (`pull-requests: write`, `issues: write`) are granted: this configuration only reads context and posts via the action’s own mechanisms; it does not request auto-commit/auto-comment. This is stricter than the generic Claude Code action default and is the actual least-privilege set for how the action is wired here.

## Risk

- Read-only CI (bench/e2e/lint/test): none — they only read code and run tests.
- `claude.yml`: low. The only conceivable under-scope is if a maintainer later wants Claude to push commits or post PR comments via the GitHub token (would need `pull-requests: write` / `contents: write`). Current wiring does not, so no behavior change is expected.

## Verification

- `yaml.safe_load` parses all 7 files; each exposes a top-level `permissions` mapping.
- docs/release scopes unchanged (diff touches only the 5 added/lifted blocks).

Scope: `.github/workflows/*.yml` only. No version/action-pin changes (those are #9/#16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)