### PR TITLE
ci: pin release.yml actions to commit SHAs + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions pinned to commit SHAs maintainable: when an upstream
+  # action ships a new release, Dependabot opens a PR bumping the SHA and
+  # updates the trailing `# vX.Y.Z` comment to the new semver. `directory: "/"`
+  # monitors every workflow under .github/workflows/. Actions left on a
+  # floating tag by design (e.g. pypa/gh-action-pypi-publish@release/v1) are
+  # not bumped because they have no SHA to advance.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     # prerequisites).
     steps:
       - name: Checkout (full history for changelog notes)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
           echo "Tag $GITHUB_REF_NAME ($GITHUB_SHA) is on main."
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Closes #16

## Why

`release.yml` runs with `id-token: write` — the PyPI trusted-publishing OIDC credential. A compromised action under that scope could exfiltrate the OIDC token. Pin the non-PyPA actions to immutable 40-hex commit SHAs (Path B).

## Action → SHA → semver mappings

| Action | Pinned SHA | Semver | How resolved/verified |
|---|---|---|---|
| `actions/checkout` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` | v5.0.1 | `git/ref/tags/v5` returned `type=commit`, used SHA directly. Confirmed via `tags?per_page=100` filtered on commit sha → tags `v5.0.1` + `v5`. Existence verified: `commits/93cb6e…` → echoes SHA. |
| `astral-sh/setup-uv` | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` | v7.6.0 | `git/ref/tags/v7` returned `type=tag` (annotated) sha `94527f2…`; dereferenced via `git/tags/94527f2…` → commit `37802ad…`. Confirmed via tag list filtered on commit sha → tags `v7.6.0` + `v7.6` + `v7`. Existence verified: `commits/37802ad…` → echoes SHA. |

All SHAs are full 40-hex and were each confirmed to exist with `gh api repos/<owner>/<repo>/commits/<sha> --jq .sha`.

## pypa/gh-action-pypi-publish

Left on its floating tag `release/v1` — **not** pinned. Per PyPA's official guidance the publish action is the publish target itself and should track its release branch.

(No other floating-tag actions exist in `release.yml`; `setup-python`/`action-gh-release` are not used — Python install is via `uv python install` and the GitHub Release is created with `gh release create`.)

## Dependabot

New `.github/dependabot.yml`:
- ecosystem `github-actions`, `directory: "/"` (monitors all `.github/workflows/*`)
- `interval: weekly`, `open-pull-requests-limit: 5`, `commit-message.prefix: ci`

This keeps the SHA pins maintainable: when upstream ships a release, Dependabot opens a PR bumping the SHA and updating the trailing `# vX.Y.Z` comment.

## Scope / validation

- Only `.github/workflows/release.yml` modified + new `.github/dependabot.yml`. No source/tests/CHANGELOG/version touched.
- Both YAML files parse (`yaml.safe_load`); pre-commit `check yaml` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)