### PR TITLE
ci: run e2e against NetBox 4.5 and 4.6 matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,19 @@ permissions:
 
 jobs:
   e2e:
+    name: e2e (${{ matrix.netbox-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Latest patch of each supported NetBox minor. A regression on one
+        # version surfaces as a per-dimension failure rather than a sweeping red.
+        netbox-version:
+          - v4.5.10
+          - v4.6.3
+    env:
+      NETBOX_IMAGE: netboxcommunity/netbox:${{ matrix.netbox-version }}
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7

--- a/justfile
+++ b/justfile
@@ -44,7 +44,8 @@ update:
 bench:
     NSC_BENCH=1 uv run pytest tests/benchmarks/ -v -s
 
-# Run live-NetBox e2e suite (requires Docker)
+# Run live-NetBox e2e suite (requires Docker). Override the NetBox image with
+# NETBOX_IMAGE=netboxcommunity/netbox:v4.6.3 just e2e
 e2e:
     docker compose -f tests/e2e/docker-compose.yml up -d
     tests/e2e/wait_for_netbox.sh

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,8 +1,16 @@
 # Live-NetBox e2e suite (Phase 3d)
 
-These tests exercise `nsc` against a real NetBox 4.5.9 container instead of
+These tests exercise `nsc` against a real NetBox container instead of
 mocked HTTP. They are gated out of the default `just test` invocation
 (`NSC_E2E=1` required) and require Docker to run.
+
+CI runs the suite as a matrix over the latest patch of each supported NetBox
+minor (currently `v4.5.10` and `v4.6.3`) with `fail-fast: false`, so a
+regression on one version surfaces per-dimension rather than as a sweeping
+red. The NetBox image is parametrized via the `NETBOX_IMAGE` env var, which
+`docker-compose.yml` interpolates (defaulting to the latest 4.5 patch so
+`just e2e` works unparametrized). Override it locally with e.g.
+`NETBOX_IMAGE=netboxcommunity/netbox:v4.6.3 just e2e`.
 
 ## Run locally
 

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -5,13 +5,16 @@
 # SUPERUSER_API_TOKEN") for the full story. In short: NetBox 4.5+ defaults to
 # v2 tokens which can't be pinned to a known plaintext via env var, so
 # wait_for_netbox.sh creates the v1 token via `docker exec` once Django is up.
-# v1 tokens remain valid for authentication in 4.5.x.
+# v1 tokens remain valid for authentication in 4.5.x and 4.6.x.
 # Bound to 127.0.0.1:8080 — never publish to 0.0.0.0; this stack runs as
 # DEBUG=true and is intentionally insecure.
 
 services:
   netbox:
-    image: netboxcommunity/netbox:v4.5.9
+    # Pin via NETBOX_IMAGE (the CI matrix overrides it per NetBox minor);
+    # the default keeps `just e2e` working unparametrized against the latest
+    # 4.5 patch, which matches the bundled OpenAPI snapshot.
+    image: ${NETBOX_IMAGE:-netboxcommunity/netbox:v4.5.10}
     depends_on:
       - postgres
       - redis

--- a/tests/e2e/wait_for_netbox.sh
+++ b/tests/e2e/wait_for_netbox.sh
@@ -3,7 +3,7 @@
 #
 # 1. Wait until Django is serving the unauthenticated login page at $NSC_URL/login/
 #    (proxy for "migrations and gunicorn are up"). 5-minute deadline; cold-start
-#    of NetBox 4.5.9 takes ~90–180 s on CI.
+#    of NetBox 4.5/4.6 takes ~90–180 s on CI.
 # 2. Create a deterministic v1 admin API token via `docker exec`, replacing any
 #    previously-bootstrapped token. Required because NetBox 4.5+ generates a
 #    random v2 token at bootstrap and never reveals the secret half — the


### PR DESCRIPTION
Closes #4 (scoped to NetBox 4.5 and 4.6 only — 4.4 explicitly out of scope per request).

## What

Extends `.github/workflows/e2e.yml` to run the full e2e suite as a `strategy.matrix` over the latest patch of each supported NetBox minor, instead of a single hardcoded `v4.5.9`.

## Image tags chosen

| Minor | Tag | Confirmation |
|-------|-----|--------------|
| 4.5 | `netboxcommunity/netbox:v4.5.10` | Latest stable v4.5 patch; verified on Docker Hub (`tag_last_pushed` 2026-05-05) |
| 4.6 | `netboxcommunity/netbox:v4.6.3` | Latest stable v4.6 patch (GA, not beta); verified on Docker Hub (`tag_last_pushed` 2026-06-19) |

Both tags confirmed to exist via `https://hub.docker.com/v2/repositories/netboxcommunity/netbox/tags/<tag>`. The v4.6 line is fully GA (v4.6.0 → v4.6.3 stable releases exist; only the early `-beta` tags were prereleases).

## How the matrix + parametrization works

- Job gains `strategy.matrix.netbox-version: [v4.5.10, v4.6.3]` with `fail-fast: false`, so a v4.6 failure does **not** cancel/mask the v4.5 leg.
- Job name is `e2e (${{ matrix.netbox-version }})`, so each dimension is clearly labeled in the checks UI.
- A job-level `env.NETBOX_IMAGE = netboxcommunity/netbox:${{ matrix.netbox-version }}` is consumed by `tests/e2e/docker-compose.yml`, which now uses `image: ${NETBOX_IMAGE:-netboxcommunity/netbox:v4.5.10}`. The `${VAR:-default}` form keeps `just e2e` working unparametrized; `docker compose config` confirmed the default resolves to `v4.5.10`.
- Override locally with `NETBOX_IMAGE=netboxcommunity/netbox:v4.6.3 just e2e`.

## Bundled schemas

No change needed — `nsc/schemas/bundled/` already ships `netbox-4.5.10.json.gz` and `netbox-4.6.0.json.gz` (both listed in `manifest.yaml`). The e2e suite fetches the live schema from the running container regardless, so the matrix does not depend on bundled snapshots.

## Validation

- YAML parses; `docker compose config` resolves the default image.
- `just lint` clean (ruff + ruff format + mypy --strict).
- `just test` green: 1145 passed, 1 skipped.
- Pre-commit `check yaml` hook passed.

## Risk

- The Docker e2e job is not a required merge gate, but it **should** pass on both legs. The v4.5 leg is essentially the existing path (just bumped 4.5.9 → 4.5.10). The v4.6.3 leg is new; `wait_for_netbox.sh` installs a v1 token via `docker exec`, and v1 tokens remain valid for auth in 4.6.x, so it is expected to pass — but the v4.6 dimension is the one to watch on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)