### PR TITLE
perf: build static command-option specs once instead of per command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ mode — plus a round of state-directory, workflow, and supply-chain hardening.
 
 ### Changed
 
+- **Faster command-tree registration / startup**. The static command-option
+  specs (global read flags and write flags) are now built once at import and
+  shared across all commands instead of being rebuilt per command, recovering a
+  startup-time regression introduced when `--workers` was added.
 - **`~/.nsc` state root hardened to `0700`** ([#90]). Defense-in-depth on the
   state directory itself; config and audit files were already `0600` and
   `logs/` already `0700`.

--- a/nsc/cli/registration.py
+++ b/nsc/cli/registration.py
@@ -273,8 +273,8 @@ def _to_typed_option(p: Parameter) -> inspect.Parameter:
     )
 
 
-def _global_flag_params() -> list[inspect.Parameter]:
-    return [
+def _build_global_flag_params() -> tuple[inspect.Parameter, ...]:
+    return (
         inspect.Parameter(
             name="output",
             kind=inspect.Parameter.KEYWORD_ONLY,
@@ -311,11 +311,11 @@ def _global_flag_params() -> list[inspect.Parameter]:
             annotation=list[str] | None,
             default=typer.Option(None, "--filter"),
         ),
-    ]
+    )
 
 
-def _write_flag_params() -> list[inspect.Parameter]:
-    return [
+def _build_write_flag_params() -> tuple[inspect.Parameter, ...]:
+    return (
         inspect.Parameter(
             name="output",
             kind=inspect.Parameter.KEYWORD_ONLY,
@@ -451,7 +451,24 @@ def _write_flag_params() -> list[inspect.Parameter]:
                 ),
             ),
         ),
-    ]
+    )
+
+
+# These flag specs are identical for every command (they do not depend on the
+# operation), so build them once at import and share the immutable tuples across
+# all registered command signatures. `inspect.Parameter` is immutable and Typer
+# only reads the `OptionInfo` specs, so sharing is safe; tuples make accidental
+# mutation fail loudly.
+_GLOBAL_FLAG_PARAMS: tuple[inspect.Parameter, ...] = _build_global_flag_params()
+_WRITE_FLAG_PARAMS: tuple[inspect.Parameter, ...] = _build_write_flag_params()
+
+
+def _global_flag_params() -> tuple[inspect.Parameter, ...]:
+    return _GLOBAL_FLAG_PARAMS
+
+
+def _write_flag_params() -> tuple[inspect.Parameter, ...]:
+    return _WRITE_FLAG_PARAMS
 
 
 def _python_type(p: Parameter) -> Any:


### PR DESCRIPTION
## The regression

`nsc/cli/registration.py` builds the dynamic command tree on every invocation. For each of ~899 write commands it called `_write_flag_params()`, and for each of ~141 read commands `_global_flag_params()`. Both functions constructed a fresh list of ~13 / ~6 `typer.Option` (`OptionInfo`) objects **every call** — but those flag params are **static**: identical for every command, independent of the operation. Rebuilding them hundreds of times cost ~50ms of startup, a regression that compounded when `--workers` was added to the write flags.

## The fix

Build the static flag-parameter specs **once at import** as module-level tuples (`_GLOBAL_FLAG_PARAMS`, `_WRITE_FLAG_PARAMS`) and return the same shared, immutable sequence on every call. Returning a `tuple` makes accidental mutation fail loudly.

Per-operation **positional path params and query params stay freshly built per command** — only the static flag tail is memoized. `sig_params` remains a fresh per-command list; only its tail contents are shared.

No flag name, type, help text, default, or ordering changed — behavior is byte-identical. `--workers` is untouched.

### Safety

Sharing the same immutable `inspect.Parameter` and `typer.OptionInfo` (a spec Typer only *reads* to build click Options) across many signatures is safe. The full 1148-test suite — which exercises many concrete read/write commands' option parsing and `--help` — stays 100% green.

## A/B benchmark (`NSC_BENCH=1 uv run pytest tests/benchmarks/ -q -s`)

Median of `nsc --help` cold start, 3 runs each:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before (this branch base) | 291.6 ms | 270.7 ms | 258.9 ms |
| after | 256.0 ms | 248.5 ms | 247.3 ms |

Recovered to ~the v1.2.1 baseline (~245 ms), removing the per-command rebuild overhead.

## Verification

- `just lint` clean (ruff + mypy --strict).
- `just test` — 1148 passed, 1 skipped (benchmark gated).
- `nsc dcim devices create --help` still lists all options (`--workers`, `--apply`, `-f/--file`, `--on-error`, `--bulk`, `--no-bulk`, `--field`, `--format`, `--strict`, `--explain`, `-o/--output`, `--columns`, `--compact`).
- A dry-run write (`--field … --workers 4 --on-error continue`) parses all flags and reports `applied: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)