### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
-## v1.3.0 — unreleased
+## v1.3.0 — 2026-06-25
 
 Minor release. A batch of user-facing features — singular alias forms, parallel
 bulk writes, dynamic shell completion, and a strict `audit_redaction: full`

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.2.1"
+version = "1.3.0"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release prep for **v1.3.0**. Bumps the version (`pyproject.toml`, `nsc/_version.py`, `uv.lock`) and dates the CHANGELOG section. Tag `v1.3.0` will be pushed on the merge commit to trigger `release.yml` (PyPI trusted publishing + GitHub Release + docs deploy).

## What's in 1.3.0
**Features:** singular alias forms (#6), `--workers N` parallel bulk writes (#3), dynamic shell completion (#2), `audit_redaction: full` (#5), `nsc skill install` for Gemini/Copilot + quarterly convention re-check (#7).
**Hardening / CI:** `~/.nsc` 0700 (#90), Node 24 runners (#9), least-privilege workflow permissions (#12), release SHA pins + Dependabot (#16), e2e matrix over NetBox 4.5/4.6 (#4).
**Perf:** static command-option specs built once (recovers a startup regression).
**Docs:** full documentation pass across README, guides, architecture, SKILL.md, CHANGELOG.

All gated by green lint + full unit suite; reference docs and AGENTS.md verified fresh.