### PR TITLE
feat(tui): list individual custom fields as selectable columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ nsc tui devices    # jump straight into the devices list
 Highlights: a collapsible resource picker, a web-UI-style filter builder (`/`),
 inline record editing with a confirm-diff save, schema-derived relationship
 drill-down, bulk edit with a per-record preview, a persisted column chooser
-(`f`), and global search (`Ctrl`+`F`). Full walkthrough in the
+(`f`) that lists each custom field individually, and global search (`Ctrl`+`F`).
+The same dotted paths work on the CLI: `nsc ls devices --columns id,name,custom_fields.rack_role`.
+Full walkthrough in the
 [Interactive TUI guide](https://thomaschristory.github.io/netbox-super-cli/guides/interactive-tui/).
 
 ## Reading

--- a/nsc/tui/columns.py
+++ b/nsc/tui/columns.py
@@ -1,6 +1,7 @@
 """Pure, Textual-free model for the column chooser.
 
-``available_columns`` lists every field the loaded records expose; a
+``available_columns`` lists every selectable field the loaded records expose
+(custom fields individually, as ``custom_fields.<name>``); a
 ``ColumnSelection`` holds an ordered list of those fields with a visible/hidden
 flag each, plus reorder operations. The screen renders this and reads back
 ``visible_in_order``.
@@ -12,19 +13,32 @@ from typing import Any
 
 
 def available_columns(records: list[dict[str, Any]]) -> list[str]:
-    """Ordered union of the records' top-level keys (first-seen order).
+    """Ordered union of the records' selectable columns (first-seen order).
 
-    Only top-level fields are offered: a foreign key or choice object stays one
-    column (the table renders it via its ``display``/``label``), so the chooser
-    shows ``site`` rather than ``site.id`` / ``site.url`` / ``site.display``.
+    Only top-level fields are offered, with one deliberate exception:
+    ``custom_fields``. A foreign key or choice object stays one column (the
+    table renders it via its ``display``/``label``), so the chooser shows
+    ``site`` rather than ``site.id`` / ``site.url`` / ``site.display``. But
+    ``custom_fields`` holds user-defined values worth their own column each, so
+    it is expanded into ``custom_fields.<name>`` entries (first-seen union of
+    the inner keys) rather than a single opaque JSON column. Records whose
+    ``custom_fields`` is absent, empty, or not a dict contribute no such column.
     """
     seen: list[str] = []
     seen_set: set[str] = set()
+
+    def _add(key: str) -> None:
+        if key not in seen_set:
+            seen_set.add(key)
+            seen.append(key)
+
     for record in records:
-        for key in record:
-            if key not in seen_set:
-                seen_set.add(key)
-                seen.append(key)
+        for key, value in record.items():
+            if key == "custom_fields" and isinstance(value, dict):
+                for name in value:
+                    _add(f"custom_fields.{name}")
+            else:
+                _add(key)
     return seen
 
 

--- a/skills/netbox-super-cli/SKILL.md
+++ b/skills/netbox-super-cli/SKILL.md
@@ -91,6 +91,11 @@ sets the default format (a `--output/-o` flag still wins over it).
 nsc ls devices --output json | jq '.[] | select(.status.value == "active")'
 ```
 
+Pick columns with `--columns` (comma-separated), including individual custom
+fields via dotted paths: `nsc ls devices --columns id,name,custom_fields.rack_role`.
+In the TUI the column chooser (`f` in a list view) lists each custom field as
+its own toggleable row.
+
 Errors come back as JSON envelopes (on stderr by default; on stdout when
 `--output json` is set). The envelope shape is locked:
 

--- a/tests/tui/test_columns.py
+++ b/tests/tui/test_columns.py
@@ -16,6 +16,55 @@ def test_available_columns_is_ordered_union_of_top_level_keys() -> None:
     assert "site.url" not in cols
 
 
+def test_available_columns_expands_custom_fields_into_dotted_subcolumns() -> None:
+    records = [{"id": 1, "name": "sw1", "custom_fields": {"rack_role": "core", "floor": 3}}]
+    cols = available_columns(records)
+    assert cols == ["id", "name", "custom_fields.rack_role", "custom_fields.floor"]
+    assert "custom_fields" not in cols
+
+
+def test_custom_fields_keys_are_first_seen_union_across_records() -> None:
+    records = [
+        {"id": 1, "custom_fields": {"a": 1, "b": 2}},
+        {"id": 2, "custom_fields": {"b": 2, "c": 3}},
+    ]
+    cols = available_columns(records)
+    assert cols == ["id", "custom_fields.a", "custom_fields.b", "custom_fields.c"]
+
+
+def test_custom_fields_object_and_null_values_still_listed() -> None:
+    records = [{"custom_fields": {"site": {"id": 1, "display": "HQ"}, "note": None, "tag": "x"}}]
+    cols = available_columns(records)
+    assert cols == ["custom_fields.site", "custom_fields.note", "custom_fields.tag"]
+
+
+def test_empty_or_missing_custom_fields_offers_no_cf_columns() -> None:
+    assert available_columns([{"id": 1, "name": "sw1"}]) == ["id", "name"]
+    assert available_columns([{"id": 1, "name": "sw1", "custom_fields": {}}]) == ["id", "name"]
+
+
+def test_non_custom_fields_objects_are_not_expanded() -> None:
+    records = [
+        {
+            "id": 1,
+            "site": {"id": 3, "display": "HQ"},
+            "status": {"value": "active", "label": "Active"},
+            "custom_fields": {"x": 1},
+        }
+    ]
+    cols = available_columns(records)
+    assert cols == ["id", "site", "status", "custom_fields.x"]
+    assert "site.display" not in cols
+    assert "status.label" not in cols
+
+
+def test_selection_round_trips_a_chosen_custom_field() -> None:
+    records = [{"id": 1, "name": "sw1", "custom_fields": {"rack_role": "core"}}]
+    sel = ColumnSelection(available=available_columns(records), visible=["name"])
+    sel.toggle("custom_fields.rack_role")
+    assert sel.visible_in_order() == ["name", "custom_fields.rack_role"]
+
+
 def test_selection_orders_visible_first_then_the_rest() -> None:
     sel = ColumnSelection(available=["id", "name", "status", "site"], visible=["name", "id"])
     assert sel.items == ["name", "id", "status", "site"]


### PR DESCRIPTION
## Summary

The TUI column chooser offered `custom_fields` as a single opaque JSON column; individual custom fields could not be toggled. This expands `custom_fields` into per-field `custom_fields.<name>` columns in `available_columns` (first-seen union of the loaded records' custom-field keys), so each custom field is individually selectable and persists like any other column.

Everything downstream already worked: `ColumnSelection` preserves dotted columns absent from `available`, `flatten._select` resolves dotted paths (scalars pass through, object CFs render via display/label/JSON, null/missing -> `""`), and persistence stores `config.columns[tag][resource]` as an opaque `list[str]` so dotted entries round-trip unchanged. So the only behavioural code change is in `nsc/tui/columns.py`.

Expansion is limited to the literal `custom_fields` key — FK and choice objects stay single columns (rendered via `display`/`label`). Records whose `custom_fields` is absent, empty, or not a dict contribute no extra column.

## Scope decision

CLI shell-completion for `custom_fields.*` is **out of scope**: completing CF names needs live record data, but the on-disk completion cache holds only the generated command-model, and the completion module must stay httpx-free / exception-swallowing. Discoverability is delivered via the TUI chooser now listing each CF, plus docs. CLI users already type `--columns custom_fields.foo` by hand; the docs make it discoverable.

## Changes

- `nsc/tui/columns.py` — `available_columns` expands `custom_fields` into dotted sub-columns; docstrings note the deliberate exception.
- `tests/tui/test_columns.py` — new unit tests (TDD, written failing first) covering expansion, first-seen union, object/null CF values, empty/missing CFs, non-expansion of FK/choice objects, and selection round-trip.
- `README.md`, `skills/netbox-super-cli/SKILL.md` — document individually-selectable custom fields and the `--columns custom_fields.<name>` CLI syntax.

## Tests

- `just lint` (ruff + ruff format + mypy --strict): pass
- `just test`: 1154 passed, 1 skipped

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)