### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
+## v1.4.0 — 2026-06-26
+
+Minor release. Three user-facing features for the interactive TUI and table
+output: individually selectable custom-field columns, local saved searches, and
+NetBox-native object colors.
+
+### Added
+
+- **Individually selectable custom fields** ([#121], closes [#118]). The TUI
+  column chooser (`f` — Fields) now expands `custom_fields` into one toggleable
+  column per custom field (`custom_fields.<name>`) instead of a single opaque
+  object. On the CLI, `--columns custom_fields.<name>` selects an individual
+  custom field (now documented).
+- **Saved searches** ([#123], closes [#119]). Named filter sets persist per
+  resource. In the TUI filter builder, `Ctrl+W` saves the current filters under
+  a name and `Ctrl+O` opens a picker to apply one (`d` deletes an entry). On the
+  CLI, `--saved <name>` re-applies a saved filter set on `list`; explicit
+  `--filter` and typed options take precedence over saved values. Names
+  containing `.` (or whitespace) are rejected to keep the config file well-formed.
+- **NetBox object colors** ([#122], closes [#120]). Role, tag, and other
+  color-bearing fields render in their NetBox-defined colors in table output. A
+  new `object_colors` setting (`auto`/`on`/`off`) and the
+  `--object-colors/--no-object-colors` flag toggle this independently of
+  `--color`; `off`, `NO_COLOR`, and non-TTY output are always respected.
+
+[#118]: https://github.com/thomaschristory/netbox-super-cli/issues/118
+[#119]: https://github.com/thomaschristory/netbox-super-cli/issues/119
+[#120]: https://github.com/thomaschristory/netbox-super-cli/issues/120
+[#121]: https://github.com/thomaschristory/netbox-super-cli/pull/121
+[#122]: https://github.com/thomaschristory/netbox-super-cli/pull/122
+[#123]: https://github.com/thomaschristory/netbox-super-cli/pull/123
+
 ## v1.3.1 — 2026-06-25
 
 Patch release. CI maintenance only — no runtime or user-facing changes.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ This is a local, per-config convenience and is unrelated to NetBox's
 server-side saved filters (`extras saved-filters`), which store web-UI query
 strings.
 
+### Object colors
+
+NetBox assigns colors to roles, tags, and similar fields. In table output `nsc`
+renders those values in their NetBox-defined colors:
+
+```sh
+uv run nsc dcim devices list                      # colored when stdout is a TTY
+uv run nsc dcim devices list --no-object-colors   # plain text
+```
+
+Toggle it independently of `--color` with the `object_colors` setting
+(`auto`/`on`/`off`) or the `--object-colors/--no-object-colors` flag. `off`,
+`NO_COLOR`, and non-TTY output are always respected, so piped or redirected
+output stays uncolored.
+
 ## Writing
 
 ```sh

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.3.1"
+version = "1.4.0"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release v1.4.0 — three user-facing features merged under the milestone.

### Included
- feat(tui): individually selectable custom-field columns (#121, closes #118)
- feat(search): local saved searches (#123, closes #119)
- feat(output): NetBox object colors with an independent toggle (#122, closes #120)

### Release mechanics
- Version bumped to 1.4.0 in `pyproject.toml`, `nsc/_version.py`, `uv.lock`.
- CHANGELOG `## v1.4.0` section added.
- README gains an "Object colors" subsection.

Tag `v1.4.0` will be pushed to `main` HEAD after merge to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)