### PR TITLE
ci: Python 3.12/3.13/3.14 matrix on one OS + fix flaky timing test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python: ["3.12", "3.13"]
+        python: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - name: Install uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Networking",
 ]
 dependencies = [

--- a/tests/cli/writes/test_bulk.py
+++ b/tests/cli/writes/test_bulk.py
@@ -367,20 +367,25 @@ def test_run_loop_concurrent_is_faster_than_sequential() -> None:
 
     requests = [_req(i) for i in range(8)]
 
-    start = time.monotonic()
-    run_loop(
-        requests,
-        operation=None,  # type: ignore[arg-type]
-        on_error="continue",
-        send_one=slow,
-        audit_attempt=lambda *_a: None,
-        to_envelope=_to_envelope,
-        workers=8,
-    )
-    concurrent_elapsed = time.monotonic() - start
+    def _elapsed(workers: int) -> float:
+        start = time.monotonic()
+        run_loop(
+            requests,
+            operation=None,  # type: ignore[arg-type]
+            on_error="continue",
+            send_one=slow,
+            audit_attempt=lambda *_a: None,
+            to_envelope=_to_envelope,
+            workers=workers,
+        )
+        return time.monotonic() - start
 
-    # 8 records * 50ms sequential = 400ms; with 8 workers it should be ~50ms.
-    assert concurrent_elapsed < 0.20
+    # Assert the speedup as a ratio against a measured sequential baseline:
+    # an absolute wall-clock threshold flakes on slow/loaded CI runners
+    # (8 * 50ms ≈ 400ms sequential vs ≈ 50ms across 8 workers).
+    sequential = _elapsed(1)
+    concurrent = _elapsed(8)
+    assert concurrent < sequential / 2
 
 
 def test_run_loop_concurrent_stop_halts_submission_after_failure() -> None:


### PR DESCRIPTION
## What

- **Test matrix**: drop the OS dimension (was `ubuntu-latest` + `macos-latest`) and run on `ubuntu-latest` only, across **Python 3.12 / 3.13 / 3.14**. The matrix's real value is Python-version coverage; `nsc` is pure Python with no per-OS logic beyond POSIX permission hardening, which the Linux job already exercises. macOS was a redundant copy.
- **pyproject**: add the `3.14` classifier.
- **Flaky test**: `test_run_loop_concurrent_is_faster_than_sequential` asserted an absolute `< 0.20s` wall-clock threshold and intermittently failed on the slow macOS runner. Now it measures a sequential baseline and asserts a **relative** speedup (`concurrent < sequential / 2`), immune to runner speed.

## ⚠️ Required-check rename

Collapsing the `os` matrix renames the job `test (ubuntu-latest, 3.12)` → `test (3.12)`. The `main` branch-protection required status check must move accordingly (`test (3.12)`), else PRs would hang waiting on a job that no longer exists. I'll apply that to protection as part of merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)