### PR TITLE
docs: add GitHub issue form templates (bug / feature / docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: 🐞 Bug report
+description: Something in nsc (the CLI or TUI) behaves incorrectly or crashes.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! The version numbers and the **exact command** make
+        most issues reproducible — please fill in as much as you can.
+
+        > [!WARNING]
+        > **Redact secrets.** Never paste your `NSC_TOKEN`, API tokens, or any
+        > credential. Replace them with `***`.
+
+  - type: input
+    id: nsc-version
+    attributes:
+      label: nsc version
+      description: Output of `nsc --version`.
+      placeholder: "nsc 1.4.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install nsc?
+      options:
+        - uv tool install
+        - pipx
+        - pip
+        - uvx (ephemeral)
+        - from source / git checkout
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version` for the interpreter nsc runs under.
+      placeholder: "3.12.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: netbox-version
+    attributes:
+      label: NetBox version
+      description: The NetBox server version nsc talks to (NetBox UI footer, or `/api/status/`).
+      placeholder: "v4.6.3"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: schema-source
+    attributes:
+      label: Which schema was nsc using?
+      description: nsc generates commands from the OpenAPI schema — a live fetch, the on-disk cache, or the bundled offline snapshot.
+      options:
+        - Live NetBox API
+        - Cached schema
+        - Bundled offline snapshot
+        - Not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command you ran
+      description: The exact `nsc ...` invocation. Redact tokens.
+      render: shell
+      placeholder: nsc dcim devices list --site-id 42 --output json
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: The actual behavior, including any error message or traceback.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / audit output
+      description: Optional. Anything else that helps — re-run with extra output if useful. Redact secrets first.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: I'm on the latest release of nsc, or I noted my version above.
+          required: true
+        - label: I removed any tokens / credentials from the command and logs above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://thomaschristory.github.io/netbox-super-cli/
+    about: Guides, the CLI/TUI reference, and configuration docs — please check here first.
+  - name: 🔐 Security vulnerability
+    url: https://github.com/thomaschristory/netbox-super-cli/security/advisories/new
+    about: Report a security issue privately. Please do NOT open a public issue for vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,35 @@
+name: 📖 Documentation issue
+description: A gap, error, or confusing part of the docs, README, or bundled SKILL.
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: where
+    attributes:
+      label: Where is the problem?
+      description: A page URL, a file path (e.g. `README.md`, `docs/...`), or a command's `--help` output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: Optional — a sentence, a corrected snippet, or a link to the right info.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement for the CLI, TUI, or output.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Describing the **problem** first (not just the
+        solution) helps us find the best fit. nsc is generated from NetBox's
+        OpenAPI schema, so features usually apply across every resource.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area?
+      options:
+        - CLI (commands, flags, output)
+        - TUI (interactive browser)
+        - Output / formatting (table, json, jsonl, yaml, csv)
+        - Config / auth / profiles
+        - Shell completion
+        - Schema / code generation
+        - Documentation
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: What are you trying to do, and where does nsc get in the way today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like nsc to do? A sketch of the command, flag, or UX is great.
+    validations:
+      required: false
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example usage
+      description: How would it look on the command line (or in the TUI)?
+      render: shell
+      placeholder: nsc dcim devices list --some-new-flag
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true


### PR DESCRIPTION
Adds structured **issue forms** under `.github/ISSUE_TEMPLATE/`, tailored to nsc.

### Templates
- **🐞 Bug report** — captures the facts that actually make NetBox-CLI bugs reproducible: `nsc --version`, install method, Python version, OS, NetBox version, **schema source** (live / cached / bundled), the exact command, actual vs expected, logs. Requires confirming secrets were redacted. Labels: `bug`.
- **✨ Feature request** — routes by area (CLI / TUI / output / config / completion / schema / docs) with problem-first framing and an example-usage field. Labels: `enhancement`.
- **📖 Documentation issue** — where/what/suggested-fix. Labels: `documentation`.
- **config.yml** — `blank_issues_enabled: false` (funnel everyone through a form), plus contact links to the **docs site** and the **private security-advisory** flow.

All four validated against the GitHub issue-form schema (types, non-empty dropdowns, unique ids, valid `render`). All referenced labels already exist in the repo.

> Note: Discussions is currently disabled on the repo, so I didn't add a "Questions" contact link. Happy to enable Discussions and wire that up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)