### PR TITLE
docs: add PR template + Discussions contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: 📖 Documentation
     url: https://thomaschristory.github.io/netbox-super-cli/
     about: Guides, the CLI/TUI reference, and configuration docs — please check here first.
+  - name: 💬 Questions & usage help
+    url: https://github.com/thomaschristory/netbox-super-cli/discussions
+    about: Ask how-to questions, share setups, or propose ideas before filing a feature request.
   - name: 🔐 Security vulnerability
     url: https://github.com/thomaschristory/netbox-super-cli/security/advisories/new
     about: Report a security issue privately. Please do NOT open a public issue for vulnerabilities.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--
+Thanks for contributing to netbox-super-cli! Keep this short — a couple of
+sentences plus the checklist is plenty. See CLAUDE.md / docs/contributing for
+conventions.
+-->
+
+## What & why
+
+<!-- What does this change, and why? Link the issue: Closes #123 -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …)
+- [ ] Tests added or updated, and `just test` passes
+- [ ] `just lint` passes (ruff + `mypy --strict`)
+- [ ] Docs / `CHANGELOG.md` updated if this is user-facing
+- [ ] Linked the related issue (e.g. `Closes #…`)


### PR DESCRIPTION
Follow-up to the issue forms (#126).

- **Enabled Discussions** on the repo and added a **💬 Questions & usage help** contact link to the issue chooser, so how-to questions land in Discussions instead of the bug form.
- **Added `.github/pull_request_template.md`** — a short checklist matching project conventions: Conventional Commit title, tests + `just test`, `just lint` (ruff + mypy --strict), docs/CHANGELOG if user-facing, linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)