### PR TITLE
chore(metadata): refresh classifiers, author, and project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,14 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-authors = [{ name = "Thomas", email = "mick27@gmail.com" }]
+authors = [{ name = "Thomas Christory" }]
 keywords = ["netbox", "cli", "openapi", "automation"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Telecommunications Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -43,7 +45,10 @@ nsc = "nsc.cli.app:main"
 
 [project.urls]
 Homepage = "https://github.com/thomaschristory/netbox-super-cli"
+Documentation = "https://thomaschristory.github.io/netbox-super-cli/"
+Source = "https://github.com/thomaschristory/netbox-super-cli"
 Issues = "https://github.com/thomaschristory/netbox-super-cli/issues"
+Changelog = "https://github.com/thomaschristory/netbox-super-cli/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Metadata-only changes to `pyproject.toml`, ready to ship with the next release (1.4.1+).

## Changes
- **Development Status**: `3 - Alpha` → `5 - Production/Stable` — reflects the semver 1.x contract and 4 shipped releases.
- **Intended Audience**: added `Information Technology` + `Telecommunications Industry` alongside `System Administrators`. These are the valid trove classifiers covering the network admin/engineer audience — there is no network-specific classifier, and PyPI rejects non-allowlisted values.
- **Author**: full name `Thomas Christory`; dropped the public email to avoid exposing it in PyPI metadata.
- **Project URLs**: added `Documentation`, `Source`, and `Changelog` so contact/reference routes through GitHub and the docs site (`Issues` is the primary contact path).

## Notes
- No code/test impact — pure packaging metadata.
- The Python 3.14 classifier was already added in #125; combined with this, the dynamic `pyversions` badge will show 3.14 once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)