### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
-## [Unreleased]
+## v1.5.0 — 2026-06-29
+
+Minor release. Saved searches become interchangeable with the NetBox web UI.
 
 ### Changed
 

--- a/nsc/_version.py
+++ b/nsc/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-super-cli"
-version = "1.4.0"
+version = "1.5.0"
 description = "Dynamic NetBox CLI generated from the live OpenAPI schema."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "netbox-super-cli"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release v1.5.0.

Bumps version (pyproject, `nsc/_version.py`, `uv.lock` self-ref) and dates the
CHANGELOG section. The release is the `v1.5.0` tag pushed after this merges.

### Headline

- **Saved searches are now NetBox-native** ([#129] / #130) — TUI `Ctrl+W`/`Ctrl+O`
  and CLI `--saved` resolve against `extras.saved-filters`, scoped per object type
  and interchangeable with the web UI, with a transparent `config.yaml` fallback
  when offline or unauthorized.

[#129]: https://github.com/thomaschristory/netbox-super-cli/issues/129

🤖 Generated with [Claude Code](https://claude.com/claude-code)