### PR TITLE
perf(startup): defer httpx import off the cold-start path (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to netbox-super-cli are tracked here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely. From v1.0.0 onward, releases follow [Semantic Versioning](https://semver.org/) and the version in `pyproject.toml` matches the git tag. Pre-1.0 milestones (Phase 1-5) were pinned by tag while `pyproject.toml` stayed at `0.0.1`.
 
+## [Unreleased]
+
+### Changed
+
+- **httpx is now kept off the `nsc --help` / cold-start path** ([#13]). httpx is
+  the single heaviest import in the tree (~65ms cold), and nothing on the startup
+  path needs an HTTP client. It was being pulled in eagerly through the
+  runtime → client → retry chain (plus `cache`, `schema`, and `login`
+  command modules). All of these now import httpx lazily, at first request. Cold
+  startup drops by roughly httpx's import cost, bringing the median back under the
+  300ms project target. A new guard test (`test_lazy_httpx_import.py`) asserts
+  httpx never loads on `nsc --help`, and the startup benchmark's threshold is
+  re-baselined to 300ms so an over-threshold skip once again signals a real
+  regression instead of firing on every run.
+
+[#13]: https://github.com/thomaschristory/netbox-super-cli/issues/13
+
 ## v1.6.3 — 2026-07-03
 
 Patch release. Stops an offline instance from rebuilding the command model from

--- a/nsc/auth/verify.py
+++ b/nsc/auth/verify.py
@@ -17,10 +17,14 @@ out of `audit.jsonl`. There is no retry loop: a single failed probe fails fast.
 
 from __future__ import annotations
 
-import httpx
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, ConfigDict
 
 from nsc.config.models import Profile
+
+if TYPE_CHECKING:
+    import httpx
 
 _DEFAULT_TIMEOUT = 10.0
 
@@ -65,6 +69,8 @@ def verify(profile: Profile, *, timeout: float = _DEFAULT_TIMEOUT) -> VerifyResu
 
     Raises `VerifyError` on any failure. Returns a `VerifyResult` on success.
     """
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     if not profile.token:
         raise VerifyError(message="profile has no token; cannot verify")
     base = str(profile.url).rstrip("/")
@@ -84,6 +90,8 @@ def verify(profile: Profile, *, timeout: float = _DEFAULT_TIMEOUT) -> VerifyResu
 
 
 def _probe_status(client: httpx.Client) -> str:
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     try:
         response = client.get("/api/status/")
     except (httpx.RequestError, OSError) as exc:
@@ -109,6 +117,8 @@ def _probe_users_me(client: httpx.Client) -> str:
     calling user's identity in the common case. If the user has no visible
     tokens (an unusual admin state), we surface "(unknown)" rather than failing.
     """
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     try:
         response = client.get("/api/users/tokens/", params={"limit": 1})
     except (httpx.RequestError, OSError) as exc:

--- a/nsc/cli/cache_commands.py
+++ b/nsc/cli/cache_commands.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from enum import StrEnum
 from typing import Annotated
 
-import httpx
 import typer
 
 from nsc.cache.store import (
@@ -45,6 +44,8 @@ def _load_config_or_empty() -> Config:
 
 
 def _fetch_live_hash(profile: Profile, *, default_timeout: float) -> str:
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     url = str(profile.url).rstrip("/") + "/api/schema/?format=json"
     headers = {"Accept": "application/json"}
     if profile.token:

--- a/nsc/http/client.py
+++ b/nsc/http/client.py
@@ -7,10 +7,8 @@ import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from types import TracebackType
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import parse_qs, urlsplit
-
-import httpx
 
 from nsc.config.models import AuditRedaction
 from nsc.config.settings import default_paths
@@ -28,6 +26,9 @@ from nsc.http.retry import (
     should_retry,
 )
 from nsc.model.command_model import HttpMethod
+
+if TYPE_CHECKING:
+    import httpx
 
 _BODY_SNIPPET_BYTES = 2048
 _HTTP_5XX_MIN = 500
@@ -50,6 +51,8 @@ class NetBoxClient:
         redaction: AuditRedaction = AuditRedaction.SAFE,
         profile_name: str | None = None,
     ) -> None:
+        import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
         if profile.token is None:
             raise ValueError("NetBoxClient requires a non-None token on the profile")
         self._url = str(profile.url).rstrip("/")
@@ -200,6 +203,8 @@ class NetBoxClient:
         record_indices: list[int] | None = None,
         sensitive_paths: tuple[str, ...] = (),
     ) -> httpx.Response:
+        import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
         policy = policy_for_method(method)
         attempt = 0
         is_write = method not in {HttpMethod.GET, HttpMethod.HEAD, HttpMethod.OPTIONS}

--- a/nsc/http/retry.py
+++ b/nsc/http/retry.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import random
 from enum import Enum
 
-import httpx
 from pydantic import BaseModel, ConfigDict
 
 from nsc.model.command_model import HttpMethod
@@ -49,6 +48,8 @@ def policy_for_method(method: HttpMethod) -> RetryPolicy:
 
 def classify_error(exc: BaseException) -> ErrorClass:
     """Map an httpx transport exception to a retry-relevant class."""
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout)):
         return ErrorClass.CONNECT
     if isinstance(exc, httpx.ReadTimeout):

--- a/nsc/schema/loader.py
+++ b/nsc/schema/loader.py
@@ -7,8 +7,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-import httpx
-
 from nsc.schema.hashing import canonical_sha256
 from nsc.schema.models import OpenAPIDocument
 
@@ -122,6 +120,8 @@ def _decode_content_encoding(raw: bytes, encoding: str, source: str) -> bytes:
 
 
 def _fetch_http_body(source: str, *, verify_ssl: bool, timeout: float) -> bytes:
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     try:
         with httpx.stream(
             "GET",

--- a/nsc/schema/source.py
+++ b/nsc/schema/source.py
@@ -20,7 +20,6 @@ import sys
 import time
 from pathlib import Path
 
-import httpx
 from ruamel.yaml import YAML
 
 from nsc.builder.build import build_command_model
@@ -67,6 +66,8 @@ def resolve_command_model(
     schema_refresh: SchemaRefresh = SchemaRefresh.ON_HASH_CHANGE,
     force_refresh: bool = False,
 ) -> CommandModel:
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     if schema_override is not None:
         loaded = load_schema(
             schema_override, verify_ssl=profile.verify_ssl, timeout=profile.timeout
@@ -112,6 +113,8 @@ def resolve_command_model(
 
 
 def _fetch_schema(url: str, profile: ResolvedProfile) -> LoadedSchema:
+    import httpx  # noqa: PLC0415  # deferred: keeps httpx off the CLI-startup path.
+
     headers: dict[str, str] = {"Accept": "application/json"}
     if profile.token:
         headers["Authorization"] = f"Token {profile.token}"

--- a/tests/benchmarks/test_startup.py
+++ b/tests/benchmarks/test_startup.py
@@ -1,7 +1,12 @@
 """Cold-start benchmark for `nsc --help`.
 
 Gated by the NSC_BENCH=1 env var so it doesn't run in normal `pytest` invocations.
-Threshold: median of three runs ≤ 250 ms on the CI runner against the bundled schema.
+Threshold: median of three runs ≤ 300 ms on the CI runner against the bundled
+schema. The threshold matches the documented project target; startup normally
+lands comfortably under it since httpx is kept off the `--help` path (issue #13).
+An over-threshold run skips (soft signal) rather than failing — so a genuine
+future regression re-fires a now-rare `OVER THRESHOLD` skip instead of being lost
+in a skip that never stopped firing.
 """
 
 from __future__ import annotations
@@ -15,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-THRESHOLD_SECONDS = 0.25
+THRESHOLD_SECONDS = 0.30
 RUNS = 3
 
 

--- a/tests/cli/test_commands_dump.py
+++ b/tests/cli/test_commands_dump.py
@@ -42,7 +42,10 @@ def _install_fake_stream(
         captured["timeout"] = kwargs.get("timeout")
         yield httpx.Response(200, stream=_Stream())
 
-    monkeypatch.setattr("nsc.schema.loader.httpx.stream", fake_stream)
+    # The loader imports httpx lazily (keeps it off the CLI-startup path, #13),
+    # so there is no `nsc.schema.loader.httpx` module attribute to patch. httpx is
+    # a shared singleton; patching `httpx.stream` reaches the loader's local import.
+    monkeypatch.setattr("httpx.stream", fake_stream)
 
 
 def test_dumps_command_model_as_json() -> None:

--- a/tests/cli/test_lazy_httpx_import.py
+++ b/tests/cli/test_lazy_httpx_import.py
@@ -1,0 +1,52 @@
+"""Guard the startup-perf rule: normal CLI startup must not import httpx.
+
+httpx is the single heaviest import in the tree (~65 ms cold). Nothing on the
+`nsc --help` path needs an HTTP client, so httpx must stay lazy — pulled in only
+when a request is actually made. See issue #13.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _import_leaves_httpx_absent(module: str) -> None:
+    code = (
+        f"import {module}; import sys; "
+        "leaked = sorted(m for m in sys.modules if m == 'httpx' or m.startswith('httpx.')); "
+        "assert not leaked, leaked"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_cli_app_does_not_import_httpx() -> None:
+    _import_leaves_httpx_absent("nsc.cli.app")
+
+
+def test_help_invocation_does_not_import_httpx(tmp_path: Path) -> None:
+    # Belt-and-braces over the import-only guard: an actual `--help` run against
+    # an unconfigured home (the cold-start path the benchmark measures) must not
+    # drag httpx in either. `-X importtime` writes every imported module to
+    # stderr; assert httpx never appears. A configured profile legitimately
+    # builds a NetBoxClient at bootstrap, so this isolates NSC_HOME to keep the
+    # guard about help-rendering, not client construction.
+    env = {**os.environ, "NSC_HOME": str(tmp_path)}
+    result = subprocess.run(
+        [sys.executable, "-X", "importtime", "-m", "nsc", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    httpx_lines = [line for line in result.stderr.splitlines() if " httpx" in line]
+    assert not httpx_lines, httpx_lines


### PR DESCRIPTION
Closes #13 (Path C: investigate + fix, then re-baseline).

## What & why

Profiling `nsc --help` with `-X importtime` showed **httpx (~65ms, the single heaviest import in the tree) loading eagerly on every startup** — through the always-imported `runtime → client → retry` chain, plus the `cache` / `schema` / `login` command modules registered in `app.py`. Nothing on the `--help` / cold-start path needs an HTTP client, so this was pure waste that had crept in over several releases (issue #13's exact prediction).

All six modules now import httpx **lazily**, at first request. Type-only references stay under `TYPE_CHECKING`.

## Result

- `-X importtime` on `nsc --help` (unconfigured home): httpx no longer appears at all.
- Local median: ~330ms → ~290ms. Local wall-clock is noisy (290–340ms under load), so the deterministic **importtime guard test** is the real proof, not the timing.
- Bench threshold re-baselined **250ms → 300ms** (the documented project target). The `OVER THRESHOLD` skip had fired on every run for ~7 releases, becoming folklore; it now passes normally and only skips on a genuine regression.

## Verification

- `just lint` — ruff + mypy --strict clean.
- `just test` — 1367 passed, 1 skipped (bench gate).
- New `tests/cli/test_lazy_httpx_import.py` guards the invariant both ways (import-only + `--help` invocation).
- 3 `test_commands_dump` tests updated: they patched the now-absent `nsc.schema.loader.httpx` attribute → patch `httpx.stream` directly instead.

**Note on the threshold:** it's defined "on the CI runner", and local hardware runs ~65ms slower + noisy. I'll confirm the real median against this PR's bench job (`continue-on-error`, informational) and tune 300ms if CI disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)